### PR TITLE
Add post-purchase review and return management

### DIFF
--- a/backend/src/main/java/com/example/silkmall/controller/ProductReviewController.java
+++ b/backend/src/main/java/com/example/silkmall/controller/ProductReviewController.java
@@ -1,0 +1,67 @@
+package com.example.silkmall.controller;
+
+import com.example.silkmall.dto.CreateProductReviewDTO;
+import com.example.silkmall.dto.ProductReviewDTO;
+import com.example.silkmall.entity.ProductReview;
+import com.example.silkmall.service.ProductReviewService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/reviews")
+public class ProductReviewController extends BaseController {
+    private final ProductReviewService productReviewService;
+
+    @Autowired
+    public ProductReviewController(ProductReviewService productReviewService) {
+        this.productReviewService = productReviewService;
+    }
+
+    @PostMapping("/order-items/{orderItemId}")
+    public ResponseEntity<ProductReviewDTO> createReview(@PathVariable Long orderItemId,
+                                                          @RequestBody CreateProductReviewDTO request) {
+        ProductReview review = new ProductReview();
+        review.setRating(request.getRating());
+        review.setComment(request.getComment());
+
+        ProductReview saved = productReviewService.createReview(orderItemId, review);
+        return created(toDto(saved));
+    }
+
+    @GetMapping("/products/{productId}")
+    public ResponseEntity<List<ProductReviewDTO>> getByProduct(@PathVariable Long productId) {
+        List<ProductReviewDTO> reviews = productReviewService.findByProductId(productId)
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+        return success(reviews);
+    }
+
+    @GetMapping("/orders/{orderId}")
+    public ResponseEntity<List<ProductReviewDTO>> getByOrder(@PathVariable Long orderId) {
+        List<ProductReviewDTO> reviews = productReviewService.findByOrderId(orderId)
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+        return success(reviews);
+    }
+
+    private ProductReviewDTO toDto(ProductReview review) {
+        return ProductReviewDTO.builder()
+                .id(review.getId())
+                .orderId(review.getOrder().getId())
+                .orderItemId(review.getOrderItem().getId())
+                .productId(review.getProduct().getId())
+                .productName(review.getProduct().getName())
+                .consumerId(review.getConsumer().getId())
+                .consumerName(review.getConsumer().getUsername())
+                .rating(review.getRating())
+                .comment(review.getComment())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/controller/ReturnRequestController.java
+++ b/backend/src/main/java/com/example/silkmall/controller/ReturnRequestController.java
@@ -1,0 +1,76 @@
+package com.example.silkmall.controller;
+
+import com.example.silkmall.dto.CreateReturnRequestDTO;
+import com.example.silkmall.dto.ProcessReturnRequestDTO;
+import com.example.silkmall.dto.ReturnRequestDTO;
+import com.example.silkmall.entity.ReturnRequest;
+import com.example.silkmall.service.ReturnRequestService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/returns")
+public class ReturnRequestController extends BaseController {
+    private final ReturnRequestService returnRequestService;
+
+    @Autowired
+    public ReturnRequestController(ReturnRequestService returnRequestService) {
+        this.returnRequestService = returnRequestService;
+    }
+
+    @PostMapping("/order-items/{orderItemId}")
+    public ResponseEntity<ReturnRequestDTO> createReturnRequest(@PathVariable Long orderItemId,
+                                                                 @RequestBody CreateReturnRequestDTO request) {
+        ReturnRequest entity = new ReturnRequest();
+        entity.setReason(request.getReason());
+
+        ReturnRequest saved = returnRequestService.createReturnRequest(orderItemId, entity);
+        return created(toDto(saved));
+    }
+
+    @PutMapping("/{id}/status")
+    public ResponseEntity<ReturnRequestDTO> processReturn(@PathVariable Long id,
+                                                           @RequestBody ProcessReturnRequestDTO request) {
+        ReturnRequest updated = returnRequestService.processReturnRequest(id, request.getStatus(), request.getResolution());
+        return success(toDto(updated));
+    }
+
+    @GetMapping("/consumers/{consumerId}")
+    public ResponseEntity<List<ReturnRequestDTO>> getByConsumer(@PathVariable Long consumerId) {
+        List<ReturnRequestDTO> requests = returnRequestService.findByConsumerId(consumerId)
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+        return success(requests);
+    }
+
+    @GetMapping("/orders/{orderId}")
+    public ResponseEntity<List<ReturnRequestDTO>> getByOrder(@PathVariable Long orderId) {
+        List<ReturnRequestDTO> requests = returnRequestService.findByOrderId(orderId)
+                .stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+        return success(requests);
+    }
+
+    private ReturnRequestDTO toDto(ReturnRequest request) {
+        return ReturnRequestDTO.builder()
+                .id(request.getId())
+                .orderId(request.getOrder().getId())
+                .orderItemId(request.getOrderItem().getId())
+                .productId(request.getProduct().getId())
+                .productName(request.getProduct().getName())
+                .consumerId(request.getConsumer().getId())
+                .consumerName(request.getConsumer().getUsername())
+                .status(request.getStatus())
+                .reason(request.getReason())
+                .resolution(request.getResolution())
+                .requestedAt(request.getRequestedAt())
+                .processedAt(request.getProcessedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/CreateProductReviewDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/CreateProductReviewDTO.java
@@ -1,0 +1,9 @@
+package com.example.silkmall.dto;
+
+import lombok.Data;
+
+@Data
+public class CreateProductReviewDTO {
+    private Integer rating;
+    private String comment;
+}

--- a/backend/src/main/java/com/example/silkmall/dto/CreateReturnRequestDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/CreateReturnRequestDTO.java
@@ -1,0 +1,8 @@
+package com.example.silkmall.dto;
+
+import lombok.Data;
+
+@Data
+public class CreateReturnRequestDTO {
+    private String reason;
+}

--- a/backend/src/main/java/com/example/silkmall/dto/ProcessReturnRequestDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/ProcessReturnRequestDTO.java
@@ -1,0 +1,9 @@
+package com.example.silkmall.dto;
+
+import lombok.Data;
+
+@Data
+public class ProcessReturnRequestDTO {
+    private String status;
+    private String resolution;
+}

--- a/backend/src/main/java/com/example/silkmall/dto/ProductReviewDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/ProductReviewDTO.java
@@ -1,0 +1,21 @@
+package com.example.silkmall.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+@Builder
+public class ProductReviewDTO {
+    private Long id;
+    private Long orderId;
+    private Long orderItemId;
+    private Long productId;
+    private String productName;
+    private Long consumerId;
+    private String consumerName;
+    private Integer rating;
+    private String comment;
+    private Date createdAt;
+}

--- a/backend/src/main/java/com/example/silkmall/dto/ReturnRequestDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/ReturnRequestDTO.java
@@ -1,0 +1,23 @@
+package com.example.silkmall.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+@Builder
+public class ReturnRequestDTO {
+    private Long id;
+    private Long orderId;
+    private Long orderItemId;
+    private Long productId;
+    private String productName;
+    private Long consumerId;
+    private String consumerName;
+    private String status;
+    private String reason;
+    private String resolution;
+    private Date requestedAt;
+    private Date processedAt;
+}

--- a/backend/src/main/java/com/example/silkmall/entity/ProductReview.java
+++ b/backend/src/main/java/com/example/silkmall/entity/ProductReview.java
@@ -1,0 +1,48 @@
+package com.example.silkmall.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+@Entity
+@Table(name = "product_reviews", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"order_item_id"})
+})
+public class ProductReview {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer rating;
+
+    @Column(length = 1000)
+    private String comment;
+
+    private Date createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_id")
+    @JsonIgnore
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_item_id")
+    @JsonIgnore
+    private OrderItem orderItem;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "consumer_id")
+    private Consumer consumer;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = new Date();
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/entity/ReturnRequest.java
+++ b/backend/src/main/java/com/example/silkmall/entity/ReturnRequest.java
@@ -1,0 +1,52 @@
+package com.example.silkmall.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+@Entity
+@Table(name = "return_requests")
+public class ReturnRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String status; // PENDING, APPROVED, REJECTED, COMPLETED
+
+    @Column(length = 1000)
+    private String reason;
+
+    @Column(length = 1000)
+    private String resolution;
+
+    private Date requestedAt;
+
+    private Date processedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_id")
+    @JsonIgnore
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_item_id")
+    @JsonIgnore
+    private OrderItem orderItem;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "consumer_id")
+    private Consumer consumer;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @PrePersist
+    protected void onCreate() {
+        requestedAt = new Date();
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/OrderItemRepository.java
@@ -1,0 +1,12 @@
+package com.example.silkmall.repository;
+
+import com.example.silkmall.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+    List<OrderItem> findByOrderId(Long orderId);
+}

--- a/backend/src/main/java/com/example/silkmall/repository/ProductReviewRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/ProductReviewRepository.java
@@ -1,0 +1,14 @@
+package com.example.silkmall.repository;
+
+import com.example.silkmall.entity.ProductReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProductReviewRepository extends JpaRepository<ProductReview, Long> {
+    boolean existsByOrderItemId(Long orderItemId);
+    List<ProductReview> findByProductId(Long productId);
+    List<ProductReview> findByOrderId(Long orderId);
+}

--- a/backend/src/main/java/com/example/silkmall/repository/ReturnRequestRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/ReturnRequestRepository.java
@@ -1,0 +1,15 @@
+package com.example.silkmall.repository;
+
+import com.example.silkmall.entity.ReturnRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+@Repository
+public interface ReturnRequestRepository extends JpaRepository<ReturnRequest, Long> {
+    boolean existsByOrderItemIdAndStatusIn(Long orderItemId, Collection<String> statuses);
+    List<ReturnRequest> findByConsumerId(Long consumerId);
+    List<ReturnRequest> findByOrderId(Long orderId);
+}

--- a/backend/src/main/java/com/example/silkmall/service/ProductReviewService.java
+++ b/backend/src/main/java/com/example/silkmall/service/ProductReviewService.java
@@ -1,0 +1,11 @@
+package com.example.silkmall.service;
+
+import com.example.silkmall.entity.ProductReview;
+
+import java.util.List;
+
+public interface ProductReviewService extends BaseService<ProductReview, Long> {
+    ProductReview createReview(Long orderItemId, ProductReview review);
+    List<ProductReview> findByProductId(Long productId);
+    List<ProductReview> findByOrderId(Long orderId);
+}

--- a/backend/src/main/java/com/example/silkmall/service/ReturnRequestService.java
+++ b/backend/src/main/java/com/example/silkmall/service/ReturnRequestService.java
@@ -1,0 +1,12 @@
+package com.example.silkmall.service;
+
+import com.example.silkmall.entity.ReturnRequest;
+
+import java.util.List;
+
+public interface ReturnRequestService extends BaseService<ReturnRequest, Long> {
+    ReturnRequest createReturnRequest(Long orderItemId, ReturnRequest request);
+    ReturnRequest processReturnRequest(Long id, String status, String resolution);
+    List<ReturnRequest> findByConsumerId(Long consumerId);
+    List<ReturnRequest> findByOrderId(Long orderId);
+}

--- a/backend/src/main/java/com/example/silkmall/service/impl/ProductReviewServiceImpl.java
+++ b/backend/src/main/java/com/example/silkmall/service/impl/ProductReviewServiceImpl.java
@@ -1,0 +1,63 @@
+package com.example.silkmall.service.impl;
+
+import com.example.silkmall.entity.OrderItem;
+import com.example.silkmall.entity.ProductReview;
+import com.example.silkmall.repository.OrderItemRepository;
+import com.example.silkmall.repository.ProductReviewRepository;
+import com.example.silkmall.service.ProductReviewService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class ProductReviewServiceImpl extends BaseServiceImpl<ProductReview, Long> implements ProductReviewService {
+    private final ProductReviewRepository reviewRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    @Autowired
+    public ProductReviewServiceImpl(ProductReviewRepository reviewRepository,
+                                    OrderItemRepository orderItemRepository) {
+        super(reviewRepository);
+        this.reviewRepository = reviewRepository;
+        this.orderItemRepository = orderItemRepository;
+    }
+
+    @Override
+    @Transactional
+    public ProductReview createReview(Long orderItemId, ProductReview review) {
+        OrderItem orderItem = orderItemRepository.findById(orderItemId)
+                .orElseThrow(() -> new RuntimeException("订单项不存在"));
+
+        if (!"DELIVERED".equals(orderItem.getOrder().getStatus())) {
+            throw new RuntimeException("只有已收货的订单才能评价");
+        }
+
+        if (reviewRepository.existsByOrderItemId(orderItemId)) {
+            throw new RuntimeException("该商品已评价过");
+        }
+
+        Integer rating = review.getRating();
+        if (rating == null || rating < 1 || rating > 5) {
+            throw new RuntimeException("评分必须在1到5之间");
+        }
+
+        review.setOrder(orderItem.getOrder());
+        review.setOrderItem(orderItem);
+        review.setProduct(orderItem.getProduct());
+        review.setConsumer(orderItem.getOrder().getConsumer());
+
+        return reviewRepository.save(review);
+    }
+
+    @Override
+    public List<ProductReview> findByProductId(Long productId) {
+        return reviewRepository.findByProductId(productId);
+    }
+
+    @Override
+    public List<ProductReview> findByOrderId(Long orderId) {
+        return reviewRepository.findByOrderId(orderId);
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/service/impl/ReturnRequestServiceImpl.java
+++ b/backend/src/main/java/com/example/silkmall/service/impl/ReturnRequestServiceImpl.java
@@ -1,0 +1,82 @@
+package com.example.silkmall.service.impl;
+
+import com.example.silkmall.entity.OrderItem;
+import com.example.silkmall.entity.ReturnRequest;
+import com.example.silkmall.repository.OrderItemRepository;
+import com.example.silkmall.repository.ReturnRequestRepository;
+import com.example.silkmall.service.ReturnRequestService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class ReturnRequestServiceImpl extends BaseServiceImpl<ReturnRequest, Long> implements ReturnRequestService {
+    private static final Set<String> ACTIVE_STATUSES = Set.of("PENDING", "APPROVED");
+    private static final Set<String> PROCESSABLE_STATUSES = Set.of("APPROVED", "REJECTED", "COMPLETED");
+
+    private final ReturnRequestRepository returnRequestRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    @Autowired
+    public ReturnRequestServiceImpl(ReturnRequestRepository returnRequestRepository,
+                                    OrderItemRepository orderItemRepository) {
+        super(returnRequestRepository);
+        this.returnRequestRepository = returnRequestRepository;
+        this.orderItemRepository = orderItemRepository;
+    }
+
+    @Override
+    @Transactional
+    public ReturnRequest createReturnRequest(Long orderItemId, ReturnRequest request) {
+        OrderItem orderItem = orderItemRepository.findById(orderItemId)
+                .orElseThrow(() -> new RuntimeException("订单项不存在"));
+
+        if (!"DELIVERED".equals(orderItem.getOrder().getStatus())) {
+            throw new RuntimeException("只有已收货的订单才能申请退货");
+        }
+
+        if (returnRequestRepository.existsByOrderItemIdAndStatusIn(orderItemId, ACTIVE_STATUSES)) {
+            throw new RuntimeException("存在尚未处理的退货申请");
+        }
+
+        request.setOrder(orderItem.getOrder());
+        request.setOrderItem(orderItem);
+        request.setConsumer(orderItem.getOrder().getConsumer());
+        request.setProduct(orderItem.getProduct());
+        request.setStatus("PENDING");
+        request.setProcessedAt(null);
+
+        return returnRequestRepository.save(request);
+    }
+
+    @Override
+    @Transactional
+    public ReturnRequest processReturnRequest(Long id, String status, String resolution) {
+        ReturnRequest request = returnRequestRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("退货申请不存在"));
+
+        if (!PROCESSABLE_STATUSES.contains(status)) {
+            throw new RuntimeException("不支持的退货处理状态");
+        }
+
+        request.setStatus(status);
+        request.setResolution(resolution);
+        request.setProcessedAt(new Date());
+
+        return returnRequestRepository.save(request);
+    }
+
+    @Override
+    public List<ReturnRequest> findByConsumerId(Long consumerId) {
+        return returnRequestRepository.findByConsumerId(consumerId);
+    }
+
+    @Override
+    public List<ReturnRequest> findByOrderId(Long orderId) {
+        return returnRequestRepository.findByOrderId(orderId);
+    }
+}

--- a/silkmall-frontend/src/App.vue
+++ b/silkmall-frontend/src/App.vue
@@ -15,6 +15,7 @@ import { RouterLink, RouterView } from 'vue-router'
 
       <nav class="primary-nav" aria-label="主导航">
         <RouterLink to="/" active-class="is-active" class="nav-link">产品中心</RouterLink>
+        <RouterLink to="/orders" active-class="is-active" class="nav-link">订单中心</RouterLink>
         <RouterLink to="/about" active-class="is-active" class="nav-link">关于项目</RouterLink>
       </nav>
     </header>

--- a/silkmall-frontend/src/router/index.ts
+++ b/silkmall-frontend/src/router/index.ts
@@ -1,6 +1,8 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 
+const OrderCenterView = () => import('../views/OrderCenterView.vue')
+
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
@@ -16,6 +18,11 @@ const router = createRouter({
       // this generates a separate chunk (About.[hash].js) for this route
       // which is lazy-loaded when the route is visited.
       component: () => import('../views/AboutView.vue'),
+    },
+    {
+      path: '/orders',
+      name: 'orders',
+      component: OrderCenterView,
     },
   ],
 })

--- a/silkmall-frontend/src/types/index.ts
+++ b/silkmall-frontend/src/types/index.ts
@@ -40,3 +40,60 @@ export interface SupplierOption {
   companyName: string
   supplierLevel?: string | null
 }
+
+export interface OrderItemDetail {
+  id: number
+  quantity: number
+  unitPrice: number
+  totalPrice: number
+  createdAt: string
+  product: {
+    id: number
+    name: string
+    mainImage?: string | null
+  }
+}
+
+export interface OrderDetail {
+  id: number
+  orderNo: string
+  totalAmount: number
+  totalQuantity: number
+  status: string
+  shippingAddress?: string | null
+  recipientName?: string | null
+  recipientPhone?: string | null
+  orderTime: string
+  paymentTime?: string | null
+  shippingTime?: string | null
+  deliveryTime?: string | null
+  orderItems: OrderItemDetail[]
+}
+
+export interface ProductReview {
+  id: number
+  orderId: number
+  orderItemId: number
+  productId: number
+  productName: string
+  consumerId: number
+  consumerName: string
+  rating: number
+  comment?: string | null
+  createdAt: string
+}
+
+export interface ReturnRequest {
+  id: number
+  orderId: number
+  orderItemId: number
+  productId: number
+  productName: string
+  consumerId: number
+  consumerName: string
+  status: string
+  reason?: string | null
+  resolution?: string | null
+  requestedAt: string
+  processedAt?: string | null
+}

--- a/silkmall-frontend/src/views/OrderCenterView.vue
+++ b/silkmall-frontend/src/views/OrderCenterView.vue
@@ -1,0 +1,696 @@
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue'
+import api from '@/services/api'
+import type { OrderDetail, OrderItemDetail, ProductReview, ReturnRequest } from '@/types'
+
+const orderIdInput = ref('')
+const loadingOrder = ref(false)
+const orderDetail = ref<OrderDetail | null>(null)
+const orderError = ref<string | null>(null)
+const actionMessage = ref<string | null>(null)
+const actionError = ref<string | null>(null)
+
+const reviews = ref<ProductReview[]>([])
+const returnRequests = ref<ReturnRequest[]>([])
+
+const activeReviewItemId = ref<number | null>(null)
+const activeReturnItemId = ref<number | null>(null)
+
+const reviewForm = reactive({
+  rating: 5,
+  comment: '',
+})
+
+const returnForm = reactive({
+  reason: '',
+})
+
+const submittingReview = ref(false)
+const submittingReturn = ref(false)
+
+const reviewMap = computed(() => {
+  const map = new Map<number, ProductReview>()
+  reviews.value.forEach((review) => {
+    map.set(review.orderItemId, review)
+  })
+  return map
+})
+
+const latestReturnMap = computed(() => {
+  const map = new Map<number, ReturnRequest>()
+  returnRequests.value.forEach((request) => {
+    const existing = map.get(request.orderItemId)
+    if (!existing || new Date(existing.requestedAt).getTime() < new Date(request.requestedAt).getTime()) {
+      map.set(request.orderItemId, request)
+    }
+  })
+  return map
+})
+
+const pendingReturnMap = computed(() => {
+  const map = new Map<number, ReturnRequest>()
+  returnRequests.value.forEach((request) => {
+    if (request.status === 'PENDING' || request.status === 'APPROVED') {
+      map.set(request.orderItemId, request)
+    }
+  })
+  return map
+})
+
+const currencyFormatter = new Intl.NumberFormat('zh-CN', {
+  style: 'currency',
+  currency: 'CNY',
+})
+
+function formatCurrency(amount?: number | null) {
+  if (typeof amount !== 'number' || Number.isNaN(amount)) return '¥0.00'
+  return currencyFormatter.format(amount)
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleString('zh-CN', { hour12: false })
+}
+
+function resetMessages() {
+  actionMessage.value = null
+  actionError.value = null
+}
+
+async function fetchOrder() {
+  resetMessages()
+  orderError.value = null
+  const trimmed = orderIdInput.value.trim()
+  if (!trimmed) {
+    orderError.value = '请输入订单ID'
+    return
+  }
+
+  const orderId = Number(trimmed)
+  if (!Number.isInteger(orderId) || orderId <= 0) {
+    orderError.value = '订单ID必须为正整数'
+    return
+  }
+
+  loadingOrder.value = true
+  try {
+    const { data } = await api.get<OrderDetail>(`/orders/${orderId}`)
+    orderDetail.value = data
+    await Promise.all([fetchReviews(data.id), fetchReturnRequests(data.id)])
+    actionMessage.value = '订单信息加载成功'
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '加载订单失败'
+    orderError.value = message
+    orderDetail.value = null
+    reviews.value = []
+    returnRequests.value = []
+  } finally {
+    loadingOrder.value = false
+  }
+}
+
+async function fetchReviews(orderId: number) {
+  try {
+    const { data } = await api.get<ProductReview[]>(`/reviews/orders/${orderId}`)
+    reviews.value = data
+  } catch (err) {
+    console.warn('加载评价信息失败', err)
+    reviews.value = []
+  }
+}
+
+async function fetchReturnRequests(orderId: number) {
+  try {
+    const { data } = await api.get<ReturnRequest[]>(`/returns/orders/${orderId}`)
+    returnRequests.value = data
+  } catch (err) {
+    console.warn('加载退货信息失败', err)
+    returnRequests.value = []
+  }
+}
+
+function openReviewForm(item: OrderItemDetail) {
+  resetMessages()
+  activeReviewItemId.value = item.id
+  reviewForm.rating = 5
+  reviewForm.comment = ''
+}
+
+function cancelReviewForm() {
+  activeReviewItemId.value = null
+}
+
+async function submitReview() {
+  if (!activeReviewItemId.value) return
+  resetMessages()
+
+  const rating = Number(reviewForm.rating)
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    actionError.value = '请给出 1 - 5 分的评分'
+    return
+  }
+
+  submittingReview.value = true
+  try {
+    const payload = {
+      rating,
+      comment: reviewForm.comment.trim() || null,
+    }
+    const { data } = await api.post<ProductReview>(`/reviews/order-items/${activeReviewItemId.value}`, payload)
+    reviews.value = reviews.value.filter((item) => item.orderItemId !== data.orderItemId)
+    reviews.value.push(data)
+    actionMessage.value = '评价提交成功'
+    cancelReviewForm()
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '提交评价失败'
+    actionError.value = message
+  } finally {
+    submittingReview.value = false
+  }
+}
+
+function openReturnForm(item: OrderItemDetail) {
+  resetMessages()
+  activeReturnItemId.value = item.id
+  returnForm.reason = ''
+}
+
+function cancelReturnForm() {
+  activeReturnItemId.value = null
+}
+
+async function submitReturnRequest() {
+  if (!activeReturnItemId.value) return
+  resetMessages()
+
+  const reason = returnForm.reason.trim()
+  if (!reason) {
+    actionError.value = '请填写退货原因'
+    return
+  }
+
+  submittingReturn.value = true
+  try {
+    const { data } = await api.post<ReturnRequest>(
+      `/returns/order-items/${activeReturnItemId.value}`,
+      { reason }
+    )
+    returnRequests.value.push(data)
+    actionMessage.value = '退货申请已提交'
+    cancelReturnForm()
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '提交退货申请失败'
+    actionError.value = message
+  } finally {
+    submittingReturn.value = false
+  }
+}
+
+const hasOrder = computed(() => !!orderDetail.value)
+</script>
+
+<template>
+  <section class="order-center">
+    <header class="order-header">
+      <h1>订单服务中心</h1>
+      <p class="subtitle">支持查看订单详情、提交评价与退货申请</p>
+    </header>
+
+    <form class="order-search" @submit.prevent="fetchOrder">
+      <label class="search-label" for="orderId">订单ID</label>
+      <div class="search-controls">
+        <input
+          id="orderId"
+          v-model="orderIdInput"
+          type="text"
+          inputmode="numeric"
+          placeholder="请输入订单ID"
+          :disabled="loadingOrder"
+        />
+        <button type="submit" :disabled="loadingOrder">
+          {{ loadingOrder ? '查询中…' : '查询订单' }}
+        </button>
+      </div>
+      <p v-if="orderError" class="feedback feedback--error">{{ orderError }}</p>
+    </form>
+
+    <transition name="fade">
+      <p v-if="actionMessage" class="feedback feedback--success">{{ actionMessage }}</p>
+    </transition>
+    <transition name="fade">
+      <p v-if="actionError" class="feedback feedback--error">{{ actionError }}</p>
+    </transition>
+
+    <section v-if="hasOrder" class="order-detail">
+      <div class="order-meta">
+        <div>
+          <h2>订单编号：{{ orderDetail!.orderNo }}</h2>
+          <p>下单时间：{{ formatDateTime(orderDetail!.orderTime) }}</p>
+        </div>
+        <div class="order-status">
+          <span class="status-tag">状态：{{ orderDetail!.status }}</span>
+          <span>总金额：{{ formatCurrency(orderDetail!.totalAmount) }}</span>
+          <span>商品数量：{{ orderDetail!.totalQuantity }}</span>
+        </div>
+      </div>
+
+      <div class="address-card" v-if="orderDetail!.shippingAddress">
+        <h3>收货信息</h3>
+        <p>{{ orderDetail!.recipientName }} {{ orderDetail!.recipientPhone }}</p>
+        <p>{{ orderDetail!.shippingAddress }}</p>
+      </div>
+
+      <section class="items-section">
+        <h3>订单商品</h3>
+        <ul class="item-list">
+          <li v-for="item in orderDetail!.orderItems" :key="item.id" class="item-card">
+            <header class="item-head">
+              <div>
+                <h4>{{ item.product.name }}</h4>
+                <p class="muted">下单数量：{{ item.quantity }} 件</p>
+              </div>
+              <div class="price-info">
+                <span>单价：{{ formatCurrency(item.unitPrice) }}</span>
+                <span>小计：{{ formatCurrency(item.totalPrice) }}</span>
+              </div>
+            </header>
+
+            <section class="item-body">
+              <div class="item-actions">
+                <div class="action-block">
+                  <strong>商品评价</strong>
+                  <template v-if="reviewMap.get(item.id)">
+                    <p class="muted">
+                      评分：{{ reviewMap.get(item.id)!.rating }} 分
+                      <span v-if="reviewMap.get(item.id)!.comment">— {{ reviewMap.get(item.id)!.comment }}</span>
+                    </p>
+                    <p class="muted">评价时间：{{ formatDateTime(reviewMap.get(item.id)!.createdAt) }}</p>
+                  </template>
+                  <template v-else>
+                    <button
+                      class="link-button"
+                      type="button"
+                      @click="openReviewForm(item)"
+                      :disabled="activeReviewItemId === item.id"
+                    >
+                      我要评价
+                    </button>
+                  </template>
+                </div>
+
+                <div class="action-block">
+                  <strong>退货申请</strong>
+                  <template v-if="latestReturnMap.get(item.id)">
+                    <p class="muted">
+                      最近状态：{{ latestReturnMap.get(item.id)!.status }}
+                      <span v-if="latestReturnMap.get(item.id)!.resolution">— {{ latestReturnMap.get(item.id)!.resolution }}</span>
+                    </p>
+                    <p class="muted">申请时间：{{ formatDateTime(latestReturnMap.get(item.id)!.requestedAt) }}</p>
+                  </template>
+                  <template v-else>
+                    <p class="muted">尚未发起退货申请</p>
+                  </template>
+                  <button
+                    class="link-button"
+                    type="button"
+                    @click="openReturnForm(item)"
+                    :disabled="pendingReturnMap.has(item.id) || activeReturnItemId === item.id"
+                  >
+                    申请退货
+                  </button>
+                  <p v-if="pendingReturnMap.has(item.id)" class="muted warning">
+                    存在待处理的退货申请
+                  </p>
+                </div>
+              </div>
+
+              <form
+                v-if="activeReviewItemId === item.id"
+                class="inline-form"
+                @submit.prevent="submitReview"
+              >
+                <label>
+                  评分
+                  <select v-model.number="reviewForm.rating" :disabled="submittingReview">
+                    <option v-for="score in 5" :key="score" :value="score">{{ score }} 分</option>
+                  </select>
+                </label>
+                <label>
+                  评价内容（可选）
+                  <textarea
+                    v-model="reviewForm.comment"
+                    rows="3"
+                    maxlength="300"
+                    placeholder="分享您的购物体验"
+                    :disabled="submittingReview"
+                  />
+                </label>
+                <div class="form-actions">
+                  <button type="submit" :disabled="submittingReview">{{ submittingReview ? '提交中…' : '提交评价' }}</button>
+                  <button type="button" class="ghost" @click="cancelReviewForm" :disabled="submittingReview">
+                    取消
+                  </button>
+                </div>
+              </form>
+
+              <form
+                v-if="activeReturnItemId === item.id"
+                class="inline-form"
+                @submit.prevent="submitReturnRequest"
+              >
+                <label>
+                  退货原因
+                  <textarea
+                    v-model="returnForm.reason"
+                    rows="3"
+                    maxlength="300"
+                    placeholder="请说明退货原因"
+                    :disabled="submittingReturn"
+                  />
+                </label>
+                <div class="form-actions">
+                  <button type="submit" :disabled="submittingReturn">{{ submittingReturn ? '提交中…' : '提交申请' }}</button>
+                  <button type="button" class="ghost" @click="cancelReturnForm" :disabled="submittingReturn">
+                    取消
+                  </button>
+                </div>
+              </form>
+            </section>
+          </li>
+        </ul>
+      </section>
+
+      <section v-if="returnRequests.length" class="timeline">
+        <h3>退货记录</h3>
+        <ul>
+          <li v-for="request in returnRequests" :key="request.id">
+            <strong>{{ request.productName }}</strong>
+            <span class="muted">状态：{{ request.status }}</span>
+            <span class="muted">申请时间：{{ formatDateTime(request.requestedAt) }}</span>
+            <span v-if="request.resolution" class="muted">处理结果：{{ request.resolution }}</span>
+          </li>
+        </ul>
+      </section>
+    </section>
+  </section>
+</template>
+
+<style scoped>
+.order-center {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.order-header h1 {
+  font-size: 1.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.order-search {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 1rem;
+  background: #fff;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04);
+}
+
+.search-label {
+  font-weight: 600;
+}
+
+.search-controls {
+  display: flex;
+  gap: 1rem;
+}
+
+.search-controls input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  font-size: 1rem;
+}
+
+.search-controls button {
+  padding: 0 1.5rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #f28e1c, #f5c342);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.search-controls button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.feedback {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.feedback--error {
+  color: #b42318;
+  background: rgba(180, 35, 24, 0.08);
+}
+
+.feedback--success {
+  color: #05603a;
+  background: rgba(5, 96, 58, 0.08);
+}
+
+.order-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.05);
+}
+
+.order-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.order-status {
+  display: grid;
+  gap: 0.25rem;
+  text-align: right;
+}
+
+.status-tag {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(242, 142, 28, 0.12);
+  color: #7a3b0c;
+  font-weight: 600;
+}
+
+.address-card {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(242, 142, 28, 0.08);
+  border: 1px solid rgba(242, 142, 28, 0.2);
+}
+
+.items-section h3,
+.timeline h3 {
+  margin-bottom: 0.75rem;
+}
+
+.item-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.item-card {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: #fafafa;
+}
+
+.item-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.price-info {
+  display: grid;
+  gap: 0.25rem;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.muted {
+  color: rgba(0, 0, 0, 0.58);
+  font-size: 0.95rem;
+}
+
+.warning {
+  color: #b54708;
+}
+
+.item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.action-block {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: #d97706;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.link-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.inline-form {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.inline-form label {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.inline-form select,
+.inline-form textarea {
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.inline-form textarea {
+  resize: vertical;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.form-actions button {
+  padding: 0.6rem 1.5rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #f28e1c, #f5c342);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.form-actions button.ghost {
+  background: transparent;
+  color: rgba(0, 0, 0, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.form-actions button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.timeline ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.timeline li {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 768px) {
+  .order-meta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .order-status {
+    text-align: left;
+  }
+
+  .item-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .price-info {
+    text-align: left;
+  }
+
+  .item-actions {
+    flex-direction: column;
+  }
+
+  .form-actions {
+    flex-direction: column;
+  }
+
+  .search-controls {
+    flex-direction: column;
+  }
+
+  .search-controls button {
+    width: 100%;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add product review and return request entities, repositories, services, and endpoints to support evaluations and returns
- create an order service center view with review/return workflows and navigation entry in the frontend

## Testing
- ./mvnw -q test *(fails: MySQL connection refused in CI environment)*
- npm run build *(fails: environment provides Node.js 18; Vite requires >=20 and crypto.hash support)*

------
https://chatgpt.com/codex/tasks/task_e_68de254616e8832eaef46c6bf190d662