### PR TITLE
feat: enrich homepage experience

### DIFF
--- a/backend/src/main/java/com/example/silkmall/controller/HomepageController.java
+++ b/backend/src/main/java/com/example/silkmall/controller/HomepageController.java
@@ -1,0 +1,23 @@
+package com.example.silkmall.controller;
+
+import com.example.silkmall.dto.home.HomepageContentDTO;
+import com.example.silkmall.service.HomepageService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/homepage")
+public class HomepageController extends BaseController {
+    private final HomepageService homepageService;
+
+    public HomepageController(HomepageService homepageService) {
+        this.homepageService = homepageService;
+    }
+
+    @GetMapping
+    public ResponseEntity<HomepageContentDTO> getHomepageContent() {
+        return success(homepageService.getHomepageContent());
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/home/HomepageAnnouncementDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/home/HomepageAnnouncementDTO.java
@@ -1,0 +1,58 @@
+package com.example.silkmall.dto.home;
+
+public class HomepageAnnouncementDTO {
+    private String id;
+    private String title;
+    private String content;
+    private String type;
+    private String publishedAt;
+    private String linkUrl;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(String publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public String getLinkUrl() {
+        return linkUrl;
+    }
+
+    public void setLinkUrl(String linkUrl) {
+        this.linkUrl = linkUrl;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/home/HomepageBannerDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/home/HomepageBannerDTO.java
@@ -1,0 +1,58 @@
+package com.example.silkmall.dto.home;
+
+public class HomepageBannerDTO {
+    private String id;
+    private String title;
+    private String description;
+    private String imageUrl;
+    private String linkUrl;
+    private String ctaText;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getLinkUrl() {
+        return linkUrl;
+    }
+
+    public void setLinkUrl(String linkUrl) {
+        this.linkUrl = linkUrl;
+    }
+
+    public String getCtaText() {
+        return ctaText;
+    }
+
+    public void setCtaText(String ctaText) {
+        this.ctaText = ctaText;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/home/HomepageContentDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/home/HomepageContentDTO.java
@@ -1,0 +1,53 @@
+package com.example.silkmall.dto.home;
+
+import com.example.silkmall.dto.ProductSummaryDTO;
+
+import java.util.List;
+
+public class HomepageContentDTO {
+    private List<HomepageBannerDTO> banners;
+    private List<ProductSummaryDTO> recommendedProducts;
+    private List<ProductSummaryDTO> hotProducts;
+    private List<HomepagePromotionDTO> promotions;
+    private List<HomepageAnnouncementDTO> announcements;
+
+    public List<HomepageBannerDTO> getBanners() {
+        return banners;
+    }
+
+    public void setBanners(List<HomepageBannerDTO> banners) {
+        this.banners = banners;
+    }
+
+    public List<ProductSummaryDTO> getRecommendedProducts() {
+        return recommendedProducts;
+    }
+
+    public void setRecommendedProducts(List<ProductSummaryDTO> recommendedProducts) {
+        this.recommendedProducts = recommendedProducts;
+    }
+
+    public List<ProductSummaryDTO> getHotProducts() {
+        return hotProducts;
+    }
+
+    public void setHotProducts(List<ProductSummaryDTO> hotProducts) {
+        this.hotProducts = hotProducts;
+    }
+
+    public List<HomepagePromotionDTO> getPromotions() {
+        return promotions;
+    }
+
+    public void setPromotions(List<HomepagePromotionDTO> promotions) {
+        this.promotions = promotions;
+    }
+
+    public List<HomepageAnnouncementDTO> getAnnouncements() {
+        return announcements;
+    }
+
+    public void setAnnouncements(List<HomepageAnnouncementDTO> announcements) {
+        this.announcements = announcements;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/home/HomepagePromotionDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/home/HomepagePromotionDTO.java
@@ -1,0 +1,70 @@
+package com.example.silkmall.dto.home;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class HomepagePromotionDTO {
+    private String id;
+    private String title;
+    private String description;
+    private BigDecimal discountRate;
+    private List<String> tags;
+    private String startDate;
+    private String endDate;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public BigDecimal getDiscountRate() {
+        return discountRate;
+    }
+
+    public void setDiscountRate(BigDecimal discountRate) {
+        this.discountRate = discountRate;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public String getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(String startDate) {
+        this.startDate = startDate;
+    }
+
+    public String getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(String endDate) {
+        this.endDate = endDate;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/repository/ProductRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/ProductRepository.java
@@ -15,6 +15,8 @@ public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpec
     Page<Product> findByCategoryId(Long categoryId, Pageable pageable);
     Page<Product> findBySupplierId(Long supplierId, Pageable pageable);
     List<Product> findTop10ByOrderBySalesDesc();
+    List<Product> findTop8ByStatusOrderByCreatedAtDesc(String status);
+    List<Product> findTop8ByStatusOrderBySalesDesc(String status);
     Page<Product> findByNameContaining(String keyword, Pageable pageable);
     long countByStatus(String status);
     long countByStockLessThanEqual(Integer stock);

--- a/backend/src/main/java/com/example/silkmall/security/SecurityConfig.java
+++ b/backend/src/main/java/com/example/silkmall/security/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/api/homepage/**").permitAll()
                 .requestMatchers("/api/products/**").permitAll()
                 .requestMatchers("/api/categories/**").permitAll()
                 .requestMatchers("/api/users/register").permitAll()

--- a/backend/src/main/java/com/example/silkmall/service/HomepageService.java
+++ b/backend/src/main/java/com/example/silkmall/service/HomepageService.java
@@ -1,0 +1,7 @@
+package com.example.silkmall.service;
+
+import com.example.silkmall.dto.home.HomepageContentDTO;
+
+public interface HomepageService {
+    HomepageContentDTO getHomepageContent();
+}

--- a/backend/src/main/java/com/example/silkmall/service/impl/HomepageServiceImpl.java
+++ b/backend/src/main/java/com/example/silkmall/service/impl/HomepageServiceImpl.java
@@ -1,0 +1,181 @@
+package com.example.silkmall.service.impl;
+
+import com.example.silkmall.dto.ProductSummaryDTO;
+import com.example.silkmall.dto.home.HomepageAnnouncementDTO;
+import com.example.silkmall.dto.home.HomepageBannerDTO;
+import com.example.silkmall.dto.home.HomepageContentDTO;
+import com.example.silkmall.dto.home.HomepagePromotionDTO;
+import com.example.silkmall.entity.Product;
+import com.example.silkmall.repository.ProductRepository;
+import com.example.silkmall.service.HomepageService;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class HomepageServiceImpl implements HomepageService {
+    private static final ZoneOffset DEFAULT_ZONE_OFFSET = ZoneOffset.ofHours(8);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    private final ProductRepository productRepository;
+
+    public HomepageServiceImpl(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    @Override
+    public HomepageContentDTO getHomepageContent() {
+        HomepageContentDTO contentDTO = new HomepageContentDTO();
+
+        List<Product> recommended = productRepository.findTop8ByStatusOrderByCreatedAtDesc("ON_SALE");
+        List<Product> hotProducts = productRepository.findTop8ByStatusOrderBySalesDesc("ON_SALE");
+
+        contentDTO.setRecommendedProducts(recommended.stream().map(this::toSummaryDTO).toList());
+        contentDTO.setHotProducts(hotProducts.stream().map(this::toSummaryDTO).toList());
+        contentDTO.setBanners(buildBanners());
+        contentDTO.setPromotions(buildPromotions());
+        contentDTO.setAnnouncements(buildAnnouncements());
+
+        return contentDTO;
+    }
+
+    private List<HomepageBannerDTO> buildBanners() {
+        List<HomepageBannerDTO> banners = new ArrayList<>();
+
+        HomepageBannerDTO banner1 = new HomepageBannerDTO();
+        banner1.setId("banner-spring");
+        banner1.setTitle("春蚕焕新季");
+        banner1.setDescription("甄选四川优质春茧，带来丝滑轻盈的新款蚕丝面料。");
+        banner1.setImageUrl("https://images.unsplash.com/photo-1523381210434-271e8be1f52b?auto=format&fit=crop&w=1200&q=80");
+        banner1.setLinkUrl("/collections/spring-release");
+        banner1.setCtaText("立即选购");
+        banners.add(banner1);
+
+        HomepageBannerDTO banner2 = new HomepageBannerDTO();
+        banner2.setId("banner-gift");
+        banner2.setTitle("企业团购礼遇");
+        banner2.setDescription("支持定制logo与专属包装，满足企业礼赠与渠道批发需求。");
+        banner2.setImageUrl("https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=1200&q=80");
+        banner2.setLinkUrl("/solutions/b2b");
+        banner2.setCtaText("获取方案");
+        banners.add(banner2);
+
+        HomepageBannerDTO banner3 = new HomepageBannerDTO();
+        banner3.setId("banner-science");
+        banner3.setTitle("蚕桑数智化中心");
+        banner3.setDescription("实时掌握原料、库存、渠道销售，助力蚕桑产业数字化升级。");
+        banner3.setImageUrl("https://images.unsplash.com/photo-1460925895917-afdab827c52f?auto=format&fit=crop&w=1200&q=80");
+        banner3.setLinkUrl("/about/platform");
+        banner3.setCtaText("了解更多");
+        banners.add(banner3);
+
+        return banners;
+    }
+
+    private List<HomepagePromotionDTO> buildPromotions() {
+        List<HomepagePromotionDTO> promotions = new ArrayList<>();
+
+        HomepagePromotionDTO springPromo = new HomepagePromotionDTO();
+        springPromo.setId("promo-spring-pack");
+        springPromo.setTitle("春季家纺上新礼包");
+        springPromo.setDescription("床品四件套、丝绵被组套8折，含免费包邮与一对一客服服务。");
+        springPromo.setDiscountRate(new BigDecimal("0.80"));
+        springPromo.setTags(List.of("限时", "家纺", "包邮"));
+        springPromo.setStartDate(formatDate(LocalDate.now().minusDays(3)));
+        springPromo.setEndDate(formatDate(LocalDate.now().plusDays(10)));
+        promotions.add(springPromo);
+
+        HomepagePromotionDTO vipPromo = new HomepagePromotionDTO();
+        vipPromo.setId("promo-vip");
+        vipPromo.setTitle("会员专享补贴");
+        vipPromo.setDescription("平台金牌供应商联合让利，会员消费累计满5000元再享95折。");
+        vipPromo.setDiscountRate(new BigDecimal("0.95"));
+        vipPromo.setTags(List.of("会员", "供应商合作"));
+        vipPromo.setStartDate(formatDate(LocalDate.now().minusDays(10)));
+        vipPromo.setEndDate(formatDate(LocalDate.now().plusDays(20)));
+        promotions.add(vipPromo);
+
+        HomepagePromotionDTO flashPromo = new HomepagePromotionDTO();
+        flashPromo.setId("promo-flash");
+        flashPromo.setTitle("周三闪购·蚕丝好物");
+        flashPromo.setDescription("每周三10:00 准时开抢，精选丝绸围巾限量秒杀，售完即止。");
+        flashPromo.setDiscountRate(new BigDecimal("0.70"));
+        flashPromo.setTags(List.of("限量", "秒杀", "周三专场"));
+        flashPromo.setStartDate(formatDate(LocalDate.now()));
+        flashPromo.setEndDate(formatDate(LocalDate.now().plusWeeks(4)));
+        promotions.add(flashPromo);
+
+        return promotions;
+    }
+
+    private List<HomepageAnnouncementDTO> buildAnnouncements() {
+        List<HomepageAnnouncementDTO> announcements = new ArrayList<>();
+
+        HomepageAnnouncementDTO notice = new HomepageAnnouncementDTO();
+        notice.setId("notice-warehouse");
+        notice.setTitle("仓配升级通知");
+        notice.setContent("华东智能仓启用夜间打包线，次日达覆盖12个核心城市。");
+        notice.setType("SYSTEM");
+        notice.setPublishedAt(formatDateTime(OffsetDateTime.now(DEFAULT_ZONE_OFFSET).minusDays(1)));
+        notice.setLinkUrl("/news/warehouse-upgrade");
+        announcements.add(notice);
+
+        HomepageAnnouncementDTO policy = new HomepageAnnouncementDTO();
+        policy.setId("notice-policy");
+        policy.setTitle("退换货政策更新");
+        policy.setContent("延长蚕丝被类目售后时效至15天，并新增在线客服绿色通道。");
+        policy.setType("POLICY");
+        policy.setPublishedAt(formatDateTime(OffsetDateTime.now(DEFAULT_ZONE_OFFSET).minusDays(3)));
+        policy.setLinkUrl("/help/return-policy");
+        announcements.add(policy);
+
+        HomepageAnnouncementDTO expo = new HomepageAnnouncementDTO();
+        expo.setId("notice-expo");
+        expo.setTitle("西部蚕桑产业博览会火热报名");
+        expo.setContent("平台将携50+供应商亮相成都会展中心，欢迎渠道商预约洽谈。");
+        expo.setType("EVENT");
+        expo.setPublishedAt(formatDateTime(OffsetDateTime.now(DEFAULT_ZONE_OFFSET).minusDays(5)));
+        expo.setLinkUrl("/events/2024-west-expo");
+        announcements.add(expo);
+
+        return announcements;
+    }
+
+    private ProductSummaryDTO toSummaryDTO(Product product) {
+        ProductSummaryDTO dto = new ProductSummaryDTO();
+        dto.setId(product.getId());
+        dto.setName(product.getName());
+        dto.setDescription(product.getDescription());
+        dto.setPrice(product.getPrice());
+        dto.setStock(product.getStock());
+        dto.setSales(product.getSales());
+        dto.setMainImage(product.getMainImage());
+        dto.setStatus(product.getStatus());
+        dto.setCreatedAt(product.getCreatedAt());
+
+        if (product.getCategory() != null) {
+            dto.setCategoryName(product.getCategory().getName());
+        }
+        if (product.getSupplier() != null) {
+            dto.setSupplierName(product.getSupplier().getCompanyName());
+            dto.setSupplierLevel(product.getSupplier().getSupplierLevel());
+        }
+
+        return dto;
+    }
+
+    private String formatDate(LocalDate date) {
+        return date.format(DATE_FORMATTER);
+    }
+
+    private String formatDateTime(OffsetDateTime dateTime) {
+        return dateTime.format(DATE_TIME_FORMATTER);
+    }
+}

--- a/silkmall-frontend/src/types/index.ts
+++ b/silkmall-frontend/src/types/index.ts
@@ -41,6 +41,42 @@ export interface SupplierOption {
   supplierLevel?: string | null
 }
 
+export interface HomepageBanner {
+  id: string
+  title: string
+  description?: string | null
+  imageUrl?: string | null
+  linkUrl?: string | null
+  ctaText?: string | null
+}
+
+export interface HomepagePromotion {
+  id: string
+  title: string
+  description: string
+  discountRate?: number | null
+  tags?: string[]
+  startDate?: string | null
+  endDate?: string | null
+}
+
+export interface HomepageAnnouncement {
+  id: string
+  title: string
+  content: string
+  type: string
+  publishedAt: string
+  linkUrl?: string | null
+}
+
+export interface HomepageContent {
+  banners: HomepageBanner[]
+  recommendedProducts: ProductSummary[]
+  hotProducts: ProductSummary[]
+  promotions: HomepagePromotion[]
+  announcements: HomepageAnnouncement[]
+}
+
 export interface OrderItemDetail {
   id: number
   quantity: number

--- a/silkmall-frontend/src/views/HomeView.vue
+++ b/silkmall-frontend/src/views/HomeView.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 import ProductCard from '@/components/ProductCard.vue'
 import api from '@/services/api'
 import type {
   CategoryOption,
+  HomepageContent,
   PageResponse,
   ProductOverview,
   ProductSummary,
@@ -14,6 +15,11 @@ const products = ref<ProductSummary[]>([])
 const overview = ref<ProductOverview | null>(null)
 const categories = ref<CategoryOption[]>([])
 const suppliers = ref<SupplierOption[]>([])
+const homepageContent = ref<HomepageContent | null>(null)
+const homepageLoading = ref(false)
+const homepageError = ref<string | null>(null)
+const activeBannerIndex = ref(0)
+let bannerTimer: ReturnType<typeof setInterval> | null = null
 const loading = ref(false)
 const error = ref<string | null>(null)
 
@@ -57,6 +63,9 @@ const pageSizeOptions = [12, 24, 48]
 const emptyState = computed(() => !loading.value && products.value.length === 0)
 const canPrev = computed(() => pagination.page > 0)
 const canNext = computed(() => pagination.page + 1 < pagination.totalPages)
+const topHotProducts = computed(() => (homepageContent.value?.hotProducts ?? []).slice(0, 5))
+const recommendationShowcase = computed(() => (homepageContent.value?.recommendedProducts ?? []).slice(0, 4))
+const announcementList = computed(() => homepageContent.value?.announcements ?? [])
 
 function normaliseAmount(value: string) {
   if (!value.trim()) return null
@@ -102,12 +111,109 @@ function buildQueryParams(resetPage = false) {
   return params
 }
 
+function nextBanner() {
+  const banners = homepageContent.value?.banners ?? []
+  if (!banners.length) return
+  activeBannerIndex.value = (activeBannerIndex.value + 1) % banners.length
+}
+
+function previousBanner() {
+  const banners = homepageContent.value?.banners ?? []
+  if (!banners.length) return
+  activeBannerIndex.value = (activeBannerIndex.value - 1 + banners.length) % banners.length
+}
+
+function goToBanner(index: number) {
+  const banners = homepageContent.value?.banners ?? []
+  if (!banners.length || index < 0 || index >= banners.length) return
+  activeBannerIndex.value = index
+}
+
+function startBannerRotation() {
+  const banners = homepageContent.value?.banners ?? []
+  if (bannerTimer || banners.length <= 1) return
+  bannerTimer = setInterval(() => {
+    nextBanner()
+  }, 8000)
+}
+
+function stopBannerRotation() {
+  if (bannerTimer) {
+    clearInterval(bannerTimer)
+    bannerTimer = null
+  }
+}
+
+function formatDiscount(discountRate?: number | null) {
+  if (typeof discountRate !== 'number' || !Number.isFinite(discountRate) || discountRate <= 0) {
+    return null
+  }
+  const scaled = Math.round(discountRate * 100) / 10
+  return Number.isInteger(scaled) ? `${scaled.toFixed(0)}折` : `${scaled.toFixed(1)}折`
+}
+
+function formatDateRange(start?: string | null, end?: string | null) {
+  const formatterOptions: Intl.DateTimeFormatOptions = { month: '2-digit', day: '2-digit' }
+  const format = (value: string) => {
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return null
+    return date.toLocaleDateString('zh-CN', formatterOptions)
+  }
+
+  const startDate = start ? format(start) : null
+  const endDate = end ? format(end) : null
+
+  if (startDate && endDate) {
+    return `${startDate} - ${endDate}`
+  }
+  if (startDate) {
+    return `${startDate} 起`
+  }
+  if (endDate) {
+    return `截至 ${endDate}`
+  }
+  return ''
+}
+
+function formatAnnouncementTime(value?: string | null) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
 async function fetchOverview() {
   try {
     const { data } = await api.get<ProductOverview>('/products/overview')
     overview.value = data
   } catch (err) {
     console.warn('无法加载统计信息', err)
+  }
+}
+
+async function fetchHomepageContent() {
+  homepageLoading.value = true
+  homepageError.value = null
+  try {
+    const { data } = await api.get<HomepageContent>('/homepage')
+    homepageContent.value = data
+    activeBannerIndex.value = 0
+    stopBannerRotation()
+    if (data.banners?.length && data.banners.length > 1) {
+      startBannerRotation()
+    }
+  } catch (err) {
+    homepageError.value = err instanceof Error ? err.message : '加载首页信息失败'
+    homepageContent.value = null
+    stopBannerRotation()
+  } finally {
+    homepageLoading.value = false
   }
 }
 
@@ -207,8 +313,17 @@ function resetFilters() {
 
 onMounted(async () => {
   pagination.size = pageSize.value
-  await Promise.all([fetchOverview(), fetchCategories(), fetchSuppliers()])
+  await Promise.all([
+    fetchHomepageContent(),
+    fetchOverview(),
+    fetchCategories(),
+    fetchSuppliers(),
+  ])
   await fetchProducts()
+})
+
+onBeforeUnmount(() => {
+  stopBannerRotation()
 })
 </script>
 
@@ -226,6 +341,95 @@ onMounted(async () => {
         <div class="bubble bubble-lg"></div>
         <div class="bubble bubble-md"></div>
         <div class="bubble bubble-sm"></div>
+      </div>
+    </section>
+
+    <section class="spotlight" aria-label="轮播推荐与热销资讯">
+      <div class="spotlight-grid">
+        <div class="banner-column">
+          <div v-if="homepageLoading" class="card loading-card">轮播内容加载中...</div>
+          <div v-else-if="homepageError" class="card error-card">{{ homepageError }}</div>
+          <div
+            v-else-if="homepageContent?.banners?.length"
+            class="banner-viewport"
+            @mouseenter="stopBannerRotation"
+            @mouseleave="startBannerRotation"
+          >
+            <article
+              v-for="(banner, index) in homepageContent.banners"
+              v-show="index === activeBannerIndex"
+              :key="banner.id"
+              class="banner-card"
+            >
+              <div
+                class="banner-media"
+                :style="banner.imageUrl ? { backgroundImage: `url(${banner.imageUrl})` } : undefined"
+                role="img"
+                :aria-label="banner.title"
+              ></div>
+              <div class="banner-body">
+                <p class="eyebrow">精选活动</p>
+                <h2>{{ banner.title }}</h2>
+                <p class="description">{{ banner.description }}</p>
+                <a v-if="banner.linkUrl" class="banner-link" :href="banner.linkUrl">
+                  {{ banner.ctaText ?? '了解详情' }}
+                </a>
+              </div>
+            </article>
+
+            <div class="banner-controls" v-if="homepageContent.banners.length > 1">
+              <button type="button" class="nav prev" @click="previousBanner" aria-label="上一条轮播">‹</button>
+              <button type="button" class="nav next" @click="nextBanner" aria-label="下一条轮播">›</button>
+              <div class="dots" role="tablist" aria-label="轮播切换">
+                <button
+                  v-for="(banner, index) in homepageContent.banners"
+                  :key="banner.id + index"
+                  type="button"
+                  :class="{ active: index === activeBannerIndex }"
+                  :aria-label="`切换到${banner.title}`"
+                  @click="goToBanner(index)"
+                ></button>
+              </div>
+            </div>
+          </div>
+          <div v-else class="card empty-card">暂无轮播内容</div>
+        </div>
+
+        <aside class="insights" aria-label="热销排行与平台公告">
+          <section class="card hot-board" aria-label="热销排行">
+            <header>
+              <h3>热销排行</h3>
+              <p>实时关注上架热度，销量驱动选品</p>
+            </header>
+            <ol v-if="topHotProducts.length">
+              <li v-for="(item, index) in topHotProducts" :key="item.id">
+                <span class="rank">{{ index + 1 }}</span>
+                <div class="detail">
+                  <p class="name">{{ item.name }}</p>
+                  <p class="meta">销量 {{ item.sales ?? 0 }} 件 · 库存 {{ item.stock ?? 0 }}</p>
+                </div>
+              </li>
+            </ol>
+            <p v-else class="empty">暂无热销数据</p>
+          </section>
+
+          <section class="card announcement-board" aria-label="平台公告">
+            <header>
+              <h3>平台公告</h3>
+              <p>物流政策、系统维护、活动预告实时掌握</p>
+            </header>
+            <ul v-if="announcementList.length">
+              <li v-for="announcement in announcementList" :key="announcement.id">
+                <span class="type">{{ announcement.type }}</span>
+                <div class="detail">
+                  <p class="title">{{ announcement.title }}</p>
+                  <p class="time">{{ formatAnnouncementTime(announcement.publishedAt) }}</p>
+                </div>
+              </li>
+            </ul>
+            <p v-else class="empty">暂无公告</p>
+          </section>
+        </aside>
       </div>
     </section>
 
@@ -249,6 +453,46 @@ onMounted(async () => {
         <span class="label">库存总量</span>
         <strong>{{ overview.totalStock }}</strong>
         <small>仓储可用库存（件）</small>
+      </div>
+    </section>
+
+    <section class="promotions" v-if="homepageContent?.promotions?.length">
+      <header class="section-header">
+        <div>
+          <p class="section-eyebrow">促销活动</p>
+          <h2>多渠道权益，驱动下单转化</h2>
+        </div>
+        <p class="section-subtitle">联合供应商补贴、限时秒杀、会员优惠等玩法覆盖全场景</p>
+      </header>
+      <div class="promotion-grid">
+        <article v-for="promotion in homepageContent.promotions" :key="promotion.id" class="promotion-card">
+          <div class="promotion-top">
+            <span v-if="formatDiscount(promotion.discountRate)" class="discount">
+              {{ formatDiscount(promotion.discountRate) }}
+            </span>
+            <div class="tags" v-if="promotion.tags?.length">
+              <span v-for="tag in promotion.tags" :key="tag" class="tag">{{ tag }}</span>
+            </div>
+          </div>
+          <h3>{{ promotion.title }}</h3>
+          <p>{{ promotion.description }}</p>
+          <footer>
+            <span>{{ formatDateRange(promotion.startDate, promotion.endDate) }}</span>
+          </footer>
+        </article>
+      </div>
+    </section>
+
+    <section class="recommendations" v-if="recommendationShowcase.length">
+      <header class="section-header">
+        <div>
+          <p class="section-eyebrow">严选推荐</p>
+          <h2>推荐好物 · 口碑热度双在线</h2>
+        </div>
+        <p class="section-subtitle">根据上新节奏与销量表现优选尖货，助力快速挑选</p>
+      </header>
+      <div class="recommendation-grid">
+        <ProductCard v-for="product in recommendationShowcase" :key="product.id" :product="product" />
       </div>
     </section>
 
@@ -418,6 +662,380 @@ onMounted(async () => {
   background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.9), rgba(242, 177, 66, 0.7));
   bottom: 30%;
   right: -5%;
+}
+
+.spotlight {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.spotlight-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 1.75rem;
+}
+
+.banner-column {
+  position: relative;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 1.5rem;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+  padding: 1.75rem;
+}
+
+.loading-card,
+.empty-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 280px;
+  font-weight: 600;
+  color: rgba(28, 28, 30, 0.75);
+}
+
+.error-card {
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+  border: 1px solid rgba(185, 28, 28, 0.2);
+}
+
+.banner-viewport {
+  position: relative;
+  overflow: hidden;
+  min-height: 320px;
+  border-radius: 1.75rem;
+  background: linear-gradient(135deg, rgba(242, 177, 66, 0.25), rgba(111, 169, 173, 0.35));
+}
+
+.banner-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 1fr);
+  gap: 2rem;
+  align-items: stretch;
+  height: 100%;
+  padding: 2.25rem;
+  color: #1c1c1e;
+}
+
+.banner-media {
+  border-radius: 1.5rem;
+  background-size: cover;
+  background-position: center;
+  min-height: 240px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+.banner-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.banner-body h2 {
+  font-size: clamp(1.5rem, 2.2vw, 2.2rem);
+  font-weight: 700;
+}
+
+.banner-body .description {
+  color: rgba(28, 28, 30, 0.7);
+  line-height: 1.6;
+}
+
+.eyebrow {
+  font-size: 0.8rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(92, 44, 12, 0.6);
+  font-weight: 600;
+}
+
+.banner-link {
+  align-self: flex-start;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #f28e1c, #f5c342);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 12px 24px rgba(242, 142, 28, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.banner-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(242, 142, 28, 0.3);
+}
+
+.banner-controls {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  pointer-events: none;
+  padding: 0 1rem;
+}
+
+.banner-controls .nav {
+  pointer-events: auto;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.85);
+  color: #1c1c1e;
+  font-size: 1.5rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.15);
+  transition: transform 0.2s ease;
+}
+
+.banner-controls .nav:hover {
+  transform: translateY(-2px);
+}
+
+.banner-controls .dots {
+  position: absolute;
+  left: 50%;
+  bottom: 1.25rem;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.5rem;
+  pointer-events: auto;
+}
+
+.banner-controls .dots button {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.banner-controls .dots button.active {
+  background: #f28e1c;
+}
+
+.insights {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.hot-board header,
+.announcement-board header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.hot-board header h3,
+.announcement-board header h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.hot-board header p,
+.announcement-board header p {
+  font-size: 0.85rem;
+  color: rgba(28, 28, 30, 0.65);
+}
+
+.hot-board ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.hot-board li {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.hot-board .rank {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(242, 177, 66, 0.18);
+  color: #c2410c;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+}
+
+.hot-board .detail .name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.hot-board .detail .meta {
+  font-size: 0.8rem;
+  color: rgba(28, 28, 30, 0.6);
+}
+
+.announcement-board ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.announcement-board li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.announcement-board .type {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(111, 169, 173, 0.15);
+  color: #0f766e;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.announcement-board .detail .title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1c1c1e;
+}
+
+.announcement-board .detail .time {
+  font-size: 0.75rem;
+  color: rgba(28, 28, 30, 0.55);
+}
+
+.card .empty {
+  font-size: 0.85rem;
+  color: rgba(28, 28, 30, 0.6);
+}
+
+.promotions {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.section-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.section-eyebrow {
+  font-size: 0.8rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(92, 44, 12, 0.6);
+  font-weight: 600;
+}
+
+.section-subtitle {
+  color: rgba(28, 28, 30, 0.6);
+  max-width: 420px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.promotion-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.promotion-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.promotion-card h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.promotion-card p {
+  color: rgba(28, 28, 30, 0.68);
+  line-height: 1.6;
+}
+
+.promotion-card footer {
+  margin-top: auto;
+  font-size: 0.8rem;
+  color: rgba(28, 28, 30, 0.6);
+}
+
+.promotion-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.discount {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(242, 142, 28, 0.15);
+  color: #c2410c;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tags .tag {
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(111, 169, 173, 0.16);
+  color: #0f766e;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.recommendations {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.recommendation-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
 }
 
 .overview {
@@ -614,9 +1232,51 @@ onMounted(async () => {
   transform: translateY(-2px);
 }
 
+@media (max-width: 1024px) {
+  .spotlight-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .banner-card {
+    grid-template-columns: 1fr;
+    padding: 2rem;
+  }
+
+  .insights {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .insights > .card {
+    flex: 1 1 260px;
+  }
+}
+
 @media (max-width: 768px) {
   .hero {
     padding: 1.75rem;
+  }
+
+  .spotlight {
+    gap: 1.25rem;
+  }
+
+  .banner-card {
+    padding: 1.75rem;
+  }
+
+  .banner-controls .nav {
+    display: none;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .promotion-grid,
+  .recommendation-grid {
+    grid-template-columns: 1fr;
   }
 
   .filter-form {
@@ -637,12 +1297,21 @@ onMounted(async () => {
   .overview-card small,
   .overview-card .label,
   .list-header p,
-  .actions button.secondary {
+  .actions button.secondary,
+  .banner-body .description,
+  .hot-board header p,
+  .announcement-board header p,
+  .announcement-board .detail .time,
+  .section-subtitle,
+  .card .empty {
     color: rgba(226, 232, 240, 0.75);
   }
 
+  .card,
   .overview-card,
   .filters,
+  .banner-viewport,
+  .promotion-card,
   .loading,
   .empty,
   .error-message {
@@ -660,6 +1329,24 @@ onMounted(async () => {
   .pagination button {
     background: rgba(242, 177, 66, 0.28);
     color: #f9fafb;
+  }
+
+  .banner-controls .nav {
+    background: rgba(15, 23, 42, 0.75);
+    color: #f9fafb;
+  }
+
+  .banner-controls .dots button {
+    background: rgba(148, 163, 184, 0.4);
+  }
+
+  .banner-controls .dots button.active {
+    background: #fbbf24;
+  }
+
+  .announcement-board .type {
+    background: rgba(45, 212, 191, 0.18);
+    color: #5eead4;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- add a homepage aggregation API with DTOs for banners, promotions, announcements, and curated products
- expose a new controller and service to deliver home content backed by existing product data
- redesign the Vue home view to consume the new API with hero carousel, hot ranking, promotions, and recommendation sections

## Testing
- npm run build *(fails: Node.js 18.20.8 is older than the required 20.19+ and Vite also reports crypto.hash missing)*
- ./mvnw test -q *(fails: unable to connect to MySQL when bootstrapping Spring context)*

------
https://chatgpt.com/codex/tasks/task_e_68de36bd224c832e95b8fcbc55680e14