### PR TITLE
Add user account table to SQL dump

### DIFF
--- a/silkmall.sql
+++ b/silkmall.sql
@@ -17,4 +17,18 @@
 SET NAMES utf8mb4;
 SET FOREIGN_KEY_CHECKS = 0;
 
+DROP TABLE IF EXISTS `user_account`;
+CREATE TABLE `user_account`  (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `login_name` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '登录名',
+  `login_password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '登录密码',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `uk_user_account_login_name`(`login_name`) USING BTREE
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = DYNAMIC;
+
+INSERT INTO `user_account` (`login_name`, `login_password`)
+VALUES
+  ('admin', 'admin123');
+
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## Summary
- create a `user_account` table with login name and password columns
- seed the table with an initial admin account

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de4c538f5c832ea2f09700af48ed5d