### PR TITLE
feat: add login workflow with role-specific access

### DIFF
--- a/silkmall-frontend/src/App.vue
+++ b/silkmall-frontend/src/App.vue
@@ -1,5 +1,31 @@
 <script setup lang="ts">
-import { RouterLink, RouterView } from 'vue-router'
+import { computed } from 'vue'
+import { RouterLink, RouterView, useRouter } from 'vue-router'
+import { useAuth } from './composables/useAuth'
+
+const router = useRouter()
+const { user, isAuthenticated, logout } = useAuth()
+
+const roleLabels: Record<string, string> = {
+  consumer: '消费者',
+  supplier: '供应商',
+  admin: '管理员',
+}
+
+const userRoleLabel = computed(() => {
+  const role = user.value?.role
+  if (!role) {
+    return '访客'
+  }
+
+  const normalizedRole = String(role).toLowerCase()
+  return roleLabels[normalizedRole] ?? role
+})
+
+const handleLogout = () => {
+  logout()
+  router.replace({ name: 'login' })
+}
 </script>
 
 <template>
@@ -13,11 +39,19 @@ import { RouterLink, RouterView } from 'vue-router'
         </div>
       </RouterLink>
 
-      <nav class="primary-nav" aria-label="主导航">
+      <nav v-if="isAuthenticated" class="primary-nav" aria-label="主导航">
         <RouterLink to="/" active-class="is-active" class="nav-link">产品中心</RouterLink>
         <RouterLink to="/orders" active-class="is-active" class="nav-link">订单中心</RouterLink>
         <RouterLink to="/about" active-class="is-active" class="nav-link">关于项目</RouterLink>
       </nav>
+
+      <div v-if="isAuthenticated" class="user-meta" aria-live="polite">
+        <div class="user-info">
+          <span class="user-role" aria-label="当前角色">{{ userRoleLabel }}</span>
+          <span class="user-name" aria-label="当前用户">{{ user?.username }}</span>
+        </div>
+        <button type="button" class="logout-button" @click="handleLogout">退出登录</button>
+      </div>
     </header>
 
     <main class="app-main">
@@ -117,6 +151,56 @@ import { RouterLink, RouterView } from 'vue-router'
   transform: translateY(0);
 }
 
+.user-meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(242, 142, 28, 0.08);
+}
+
+.user-info {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.user-role {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #f28e1c;
+}
+
+.user-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1c1c1e;
+}
+
+.logout-button {
+  appearance: none;
+  border: none;
+  background: linear-gradient(135deg, #f28e1c, #f5c342);
+  color: #fff;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(242, 142, 28, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.logout-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(242, 142, 28, 0.28);
+}
+
+.logout-button:active {
+  transform: translateY(0);
+}
+
 .app-main {
   flex: 1;
   padding-bottom: 3rem;
@@ -134,6 +218,7 @@ import { RouterLink, RouterView } from 'vue-router'
   .app-header {
     flex-direction: column;
     align-items: flex-start;
+    gap: 1rem;
   }
 
   .primary-nav {
@@ -145,19 +230,27 @@ import { RouterLink, RouterView } from 'vue-router'
     flex: 1;
     text-align: center;
   }
+
+  .user-meta {
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
   .brand-subtitle,
   .nav-link,
-  .app-footer {
+  .app-footer,
+  .user-name {
     color: rgba(255, 255, 255, 0.7);
   }
 
-  .nav-link:hover,
-  .nav-link.is-active {
-    color: #ffffff;
+  .user-meta {
     background: rgba(242, 177, 66, 0.15);
+  }
+
+  .logout-button {
+    box-shadow: 0 10px 20px rgba(242, 177, 66, 0.25);
   }
 
   .app-footer {

--- a/silkmall-frontend/src/composables/useAuth.ts
+++ b/silkmall-frontend/src/composables/useAuth.ts
@@ -1,0 +1,69 @@
+import { computed, ref } from 'vue'
+import type { AuthUser } from '../types/auth'
+
+const STORAGE_KEY = 'silkmall-auth-user'
+
+function loadStoredUser(): AuthUser | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) {
+    return null
+  }
+
+  try {
+    return JSON.parse(raw) as AuthUser
+  } catch (error) {
+    console.warn('[SilkMall] 无法解析本地缓存的用户信息', error)
+    window.localStorage.removeItem(STORAGE_KEY)
+    return null
+  }
+}
+
+const authUser = ref<AuthUser | null>(loadStoredUser())
+
+function persistUser(user: AuthUser | null) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  if (user) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(user))
+  } else {
+    window.localStorage.removeItem(STORAGE_KEY)
+  }
+}
+
+export function setAuthUser(user: AuthUser | null) {
+  authUser.value = user
+  persistUser(user)
+}
+
+export function getAuthUser(): AuthUser | null {
+  if (!authUser.value) {
+    authUser.value = loadStoredUser()
+  }
+  return authUser.value
+}
+
+export function isAuthenticated(): boolean {
+  return getAuthUser() !== null
+}
+
+export function useAuth() {
+  const user = computed(() => authUser.value)
+  const authenticated = computed(() => user.value !== null)
+
+  const logout = () => {
+    setAuthUser(null)
+  }
+
+  return {
+    user,
+    isAuthenticated: authenticated,
+    setUser: setAuthUser,
+    logout,
+  }
+}

--- a/silkmall-frontend/src/router/index.ts
+++ b/silkmall-frontend/src/router/index.ts
@@ -1,30 +1,72 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
+import { isAuthenticated } from '../composables/useAuth'
 
+const LoginView = () => import('../views/LoginView.vue')
 const OrderCenterView = () => import('../views/OrderCenterView.vue')
+const AboutView = () => import('../views/AboutView.vue')
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
     {
+      path: '/login',
+      name: 'login',
+      component: LoginView,
+      meta: {
+        public: true,
+      },
+    },
+    {
       path: '/',
       name: 'home',
       component: HomeView,
+      meta: {
+        requiresAuth: true,
+      },
     },
     {
       path: '/about',
       name: 'about',
-      // route level code-splitting
-      // this generates a separate chunk (About.[hash].js) for this route
-      // which is lazy-loaded when the route is visited.
-      component: () => import('../views/AboutView.vue'),
+      component: AboutView,
+      meta: {
+        requiresAuth: true,
+      },
     },
     {
       path: '/orders',
       name: 'orders',
       component: OrderCenterView,
+      meta: {
+        requiresAuth: true,
+      },
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      redirect: '/',
     },
   ],
+})
+
+router.beforeEach((to, from, next) => {
+  const loggedIn = isAuthenticated()
+
+  if (to.meta?.requiresAuth && !loggedIn) {
+    next({ name: 'login', query: { redirect: to.fullPath } })
+    return
+  }
+
+  if (to.name === 'login' && loggedIn) {
+    const redirectTarget = typeof to.query.redirect === 'string' ? to.query.redirect : undefined
+    if (redirectTarget) {
+      next({ path: redirectTarget })
+    } else {
+      next({ name: 'home' })
+    }
+    return
+  }
+
+  next()
 })
 
 export default router

--- a/silkmall-frontend/src/services/auth.ts
+++ b/silkmall-frontend/src/services/auth.ts
@@ -1,0 +1,7 @@
+import api from './api'
+import type { AuthUser, LoginPayload } from '../types/auth'
+
+export async function login(payload: LoginPayload) {
+  const response = await api.post<AuthUser>('/auth/login', payload)
+  return response.data
+}

--- a/silkmall-frontend/src/types/auth.ts
+++ b/silkmall-frontend/src/types/auth.ts
@@ -1,0 +1,16 @@
+export type UserRole = 'consumer' | 'supplier' | 'admin'
+
+export interface AuthUser {
+  id: number
+  username: string
+  role: UserRole | string
+  email?: string | null
+  phone?: string | null
+  address?: string | null
+  [key: string]: unknown
+}
+
+export interface LoginPayload {
+  username: string
+  password: string
+}

--- a/silkmall-frontend/src/views/LoginView.vue
+++ b/silkmall-frontend/src/views/LoginView.vue
@@ -1,0 +1,392 @@
+<script setup lang="ts">
+import { reactive, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { login } from '../services/auth'
+import { useAuth } from '../composables/useAuth'
+
+interface LoginFormState {
+  username: string
+  password: string
+  captcha: string
+}
+
+const route = useRoute()
+const router = useRouter()
+const { setUser } = useAuth()
+
+const form = reactive<LoginFormState>({
+  username: '',
+  password: '',
+  captcha: '',
+})
+
+const loading = ref(false)
+const errorMessage = ref('')
+const captchaCode = ref(generateCaptcha())
+
+function generateCaptcha(): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+  let result = ''
+  for (let index = 0; index < 4; index += 1) {
+    const randomIndex = Math.floor(Math.random() * chars.length)
+    result += chars[randomIndex]
+  }
+  return result
+}
+
+function refreshCaptcha() {
+  captchaCode.value = generateCaptcha()
+}
+
+function normalizeRedirect(target?: string) {
+  if (!target || typeof target !== 'string') {
+    return '/'
+  }
+
+  if (!target.startsWith('/')) {
+    return '/'
+  }
+
+  return target
+}
+
+async function handleSubmit() {
+  if (loading.value) {
+    return
+  }
+
+  errorMessage.value = ''
+
+  if (!form.username.trim() || !form.password) {
+    errorMessage.value = '请输入用户名和密码'
+    return
+  }
+
+  if (form.captcha.trim().toUpperCase() !== captchaCode.value) {
+    errorMessage.value = '验证码错误，请重新输入'
+    form.captcha = ''
+    refreshCaptcha()
+    return
+  }
+
+  loading.value = true
+  try {
+    const user = await login({
+      username: form.username.trim(),
+      password: form.password,
+    })
+
+    setUser(user)
+    const redirectTarget = normalizeRedirect(route.query.redirect as string | undefined)
+    router.replace(redirectTarget)
+  } catch (error) {
+    if (error instanceof Error) {
+      errorMessage.value = error.message
+    } else {
+      errorMessage.value = '登录失败，请稍后重试'
+    }
+    refreshCaptcha()
+    form.captcha = ''
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <section class="login-container">
+    <div class="login-card" role="form" aria-labelledby="login-title">
+      <header class="login-header">
+        <h1 id="login-title">统一登录</h1>
+        <p class="login-subtitle">请使用分配的角色账号登录以访问 SilkMall 平台</p>
+      </header>
+
+      <form class="login-form" @submit.prevent="handleSubmit">
+        <label class="form-field">
+          <span class="field-label">用户名</span>
+          <input
+            v-model.trim="form.username"
+            type="text"
+            name="username"
+            autocomplete="username"
+            placeholder="请输入账号"
+            required
+          />
+        </label>
+
+        <label class="form-field">
+          <span class="field-label">密码</span>
+          <input
+            v-model="form.password"
+            type="password"
+            name="password"
+            autocomplete="current-password"
+            placeholder="请输入密码"
+            required
+          />
+        </label>
+
+        <div class="form-field captcha-field">
+          <label class="captcha-input">
+            <span class="field-label">验证码</span>
+            <input
+              v-model="form.captcha"
+              type="text"
+              name="captcha"
+              placeholder="请输入验证码"
+              maxlength="4"
+              required
+            />
+          </label>
+          <button type="button" class="captcha-display" @click="refreshCaptcha" title="点击刷新验证码">
+            <span aria-hidden="true">{{ captchaCode }}</span>
+            <span class="sr-only">点击刷新验证码</span>
+          </button>
+        </div>
+
+        <p v-if="errorMessage" class="form-error" role="alert">{{ errorMessage }}</p>
+
+        <button class="submit-button" type="submit" :disabled="loading">
+          {{ loading ? '正在登录…' : '登录' }}
+        </button>
+      </form>
+
+      <aside class="login-hint" aria-live="polite">
+        <h2>角色账号说明</h2>
+        <ul>
+          <li><strong>消费者：</strong>用户名 <code>consumer_01</code>，密码 <code>Consumer@123</code></li>
+          <li><strong>供应商：</strong>用户名 <code>supplier_01</code>，密码 <code>Supplier@123</code></li>
+          <li><strong>管理员：</strong>用户名 <code>admin_01</code>，密码 <code>Admin@123</code></li>
+        </ul>
+        <p>如需修改默认密码，请登录后前往账号管理模块。</p>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.login-container {
+  display: grid;
+  place-items: center;
+  min-height: calc(100vh - 6rem);
+  padding: 2rem 1.5rem 3rem;
+  background: linear-gradient(135deg, rgba(245, 208, 197, 0.4), rgba(242, 142, 28, 0.18));
+}
+
+.login-card {
+  width: min(960px, 100%);
+  background: #fff;
+  border-radius: 1.5rem;
+  box-shadow: 0 25px 55px rgba(15, 23, 42, 0.1);
+  padding: 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+}
+
+.login-header {
+  grid-column: 1 / -1;
+}
+
+.login-header h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1c1c1e;
+}
+
+.login-subtitle {
+  margin-top: 0.75rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field-label {
+  font-weight: 600;
+  color: #374151;
+}
+
+input[type='text'],
+input[type='password'] {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(248, 250, 252, 0.8);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  font-size: 1rem;
+}
+
+input[type='text']:focus,
+input[type='password']:focus {
+  outline: none;
+  border-color: #f28e1c;
+  box-shadow: 0 0 0 3px rgba(242, 142, 28, 0.15);
+}
+
+.captcha-field {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+}
+
+.captcha-input {
+  flex: 1;
+}
+
+.captcha-display {
+  display: grid;
+  place-items: center;
+  min-width: 120px;
+  height: 54px;
+  border-radius: 0.9rem;
+  border: none;
+  background: repeating-linear-gradient(
+      45deg,
+      rgba(242, 142, 28, 0.2),
+      rgba(242, 142, 28, 0.2) 10px,
+      rgba(245, 195, 66, 0.25) 10px,
+      rgba(245, 195, 66, 0.25) 20px
+    );
+  color: #9a3412;
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: 0.4rem;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(242, 142, 28, 0.35);
+  transition: transform 0.2s ease;
+}
+
+.captcha-display:hover {
+  transform: translateY(-1px);
+}
+
+.form-error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.submit-button {
+  appearance: none;
+  border: none;
+  border-radius: 0.9rem;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, #f28e1c, #f5c342);
+  cursor: pointer;
+  box-shadow: 0 20px 35px rgba(242, 142, 28, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submit-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 40px rgba(242, 142, 28, 0.28);
+}
+
+.submit-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+
+.login-hint {
+  background: rgba(242, 142, 28, 0.06);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  color: #4b5563;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.login-hint h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #9a3412;
+}
+
+.login-hint ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.login-hint code {
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.45rem;
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .login-card {
+    padding: 2rem 1.5rem;
+  }
+
+  .captcha-field {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .captcha-display {
+    width: 100%;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .login-card {
+    background: rgba(17, 24, 39, 0.8);
+    box-shadow: 0 25px 55px rgba(0, 0, 0, 0.35);
+    backdrop-filter: blur(12px);
+  }
+
+  .login-header h1,
+  .login-subtitle,
+  .field-label,
+  .login-hint,
+  input[type='text'],
+  input[type='password'] {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  input[type='text'],
+  input[type='password'] {
+    background: rgba(31, 41, 55, 0.65);
+    border-color: rgba(148, 163, 184, 0.35);
+  }
+
+  .login-hint {
+    background: rgba(242, 177, 66, 0.12);
+  }
+}
+</style>

--- a/silkmall.sql
+++ b/silkmall.sql
@@ -17,4 +17,142 @@
 SET NAMES utf8mb4;
 SET FOREIGN_KEY_CHECKS = 0;
 
+USE `silkmall`;
+
+-- 预置统一登录所需的核心账号
+INSERT INTO `consumers` (
+  `id`,
+  `username`,
+  `password`,
+  `email`,
+  `phone`,
+  `address`,
+  `created_at`,
+  `updated_at`,
+  `role`,
+  `enabled`,
+  `real_name`,
+  `id_card`,
+  `avatar`,
+  `points`,
+  `membership_level`
+) VALUES (
+  1001,
+  'consumer_01',
+  '$2b$12$7ypKSVf7k9z0HuiS2vhd..NY342XQ3dwKP5QPKgiLmxgVxbFiOLgq',
+  'consumer01@silkmall.cn',
+  '13800000001',
+  '江苏省苏州市工业园区蚕桑大道88号',
+  NOW(),
+  NOW(),
+  'consumer',
+  1,
+  '张小丝',
+  '320500199001011234',
+  NULL,
+  1200,
+  2
+) ON DUPLICATE KEY UPDATE
+  `password` = VALUES(`password`),
+  `email` = VALUES(`email`),
+  `phone` = VALUES(`phone`),
+  `address` = VALUES(`address`),
+  `role` = VALUES(`role`),
+  `enabled` = VALUES(`enabled`),
+  `updated_at` = NOW(),
+  `real_name` = VALUES(`real_name`),
+  `id_card` = VALUES(`id_card`),
+  `avatar` = VALUES(`avatar`),
+  `points` = VALUES(`points`),
+  `membership_level` = VALUES(`membership_level`);
+
+INSERT INTO `suppliers` (
+  `id`,
+  `username`,
+  `password`,
+  `email`,
+  `phone`,
+  `address`,
+  `created_at`,
+  `updated_at`,
+  `role`,
+  `enabled`,
+  `company_name`,
+  `business_license`,
+  `contact_person`,
+  `join_date`,
+  `supplier_level`,
+  `status`
+) VALUES (
+  2001,
+  'supplier_01',
+  '$2b$12$OImu..TfxXwcajVW4VgVMeAsTY1.C.N/.oB6SI.FAPIad3b6/niOu',
+  'supplier01@silkmall.cn',
+  '13900000001',
+  '浙江省杭州市蚕桑智谷66号',
+  NOW(),
+  NOW(),
+  'supplier',
+  1,
+  '丝路供应链科技有限公司',
+  '91330100MA2HXXXXXX',
+  '李云',
+  CURDATE(),
+  'A级合作伙伴',
+  'active'
+) ON DUPLICATE KEY UPDATE
+  `password` = VALUES(`password`),
+  `email` = VALUES(`email`),
+  `phone` = VALUES(`phone`),
+  `address` = VALUES(`address`),
+  `role` = VALUES(`role`),
+  `enabled` = VALUES(`enabled`),
+  `updated_at` = NOW(),
+  `company_name` = VALUES(`company_name`),
+  `business_license` = VALUES(`business_license`),
+  `contact_person` = VALUES(`contact_person`),
+  `join_date` = VALUES(`join_date`),
+  `supplier_level` = VALUES(`supplier_level`),
+  `status` = VALUES(`status`);
+
+INSERT INTO `admins` (
+  `id`,
+  `username`,
+  `password`,
+  `email`,
+  `phone`,
+  `address`,
+  `created_at`,
+  `updated_at`,
+  `role`,
+  `enabled`,
+  `department`,
+  `position`,
+  `permissions`
+) VALUES (
+  3001,
+  'admin_01',
+  '$2b$12$DFM88bML5r2BL4mK6e0qwe8LQakyDChhdui28r/J24ZQ2/6VCcGKq',
+  'admin01@silkmall.cn',
+  '13700000001',
+  '上海市浦东新区数字贸易中心28F',
+  NOW(),
+  NOW(),
+  'admin',
+  1,
+  '平台运营中心',
+  '系统管理员',
+  'PRODUCT_MANAGE,ORDER_REVIEW,USER_AUDIT'
+) ON DUPLICATE KEY UPDATE
+  `password` = VALUES(`password`),
+  `email` = VALUES(`email`),
+  `phone` = VALUES(`phone`),
+  `address` = VALUES(`address`),
+  `role` = VALUES(`role`),
+  `enabled` = VALUES(`enabled`),
+  `updated_at` = NOW(),
+  `department` = VALUES(`department`),
+  `position` = VALUES(`position`),
+  `permissions` = VALUES(`permissions`);
+
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## Summary
- add a dedicated login view with captcha validation and credential hints for each role
- introduce an auth composable/service pair and router guards so all core routes require authentication
- surface the active user in the shell and seed the SQL dump with consumer, supplier, and admin accounts

## Testing
- npm run build *(fails: local Node.js 18.20.8 is below Vite's required >=20.19)*

------
https://chatgpt.com/codex/tasks/task_e_68de73216834832e9bd34b82fb078007