### PR TITLE
Preserve product creation timestamps during updates

### DIFF
--- a/backend/src/main/java/com/example/silkmall/controller/ProductController.java
+++ b/backend/src/main/java/com/example/silkmall/controller/ProductController.java
@@ -61,10 +61,14 @@ public class ProductController extends BaseController {
         if (existing.isEmpty()) {
             return notFound("产品不存在");
         }
-        if (!canManageProduct(currentUser, existing.get())) {
+        Product existingProduct = existing.get();
+        if (!canManageProduct(currentUser, existingProduct)) {
             return redirectForUser(currentUser);
         }
         product.setId(id);
+        if (product.getCreatedAt() == null) {
+            product.setCreatedAt(existingProduct.getCreatedAt());
+        }
         return success(productService.save(product));
     }
 


### PR DESCRIPTION
## Summary
- keep the original creation timestamp when updating a product so the database column is never set to null
- reuse the already-loaded entity for authorization checks to avoid redundant lookups

## Testing
- ./mvnw -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e0a1017fb0832ea7643c290d44384e