### PR TITLE
feat: add product detail view to product center

### DIFF
--- a/backend/src/main/java/com/example/silkmall/dto/OrderDetailDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/OrderDetailDTO.java
@@ -1,0 +1,126 @@
+package com.example.silkmall.dto;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class OrderDetailDTO {
+    private Long id;
+    private String orderNo;
+    private BigDecimal totalAmount;
+    private Integer totalQuantity;
+    private String status;
+    private String shippingAddress;
+    private String recipientName;
+    private String recipientPhone;
+    private Date orderTime;
+    private Date paymentTime;
+    private Date shippingTime;
+    private Date deliveryTime;
+    private List<OrderItemDetailDTO> orderItems = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getOrderNo() {
+        return orderNo;
+    }
+
+    public void setOrderNo(String orderNo) {
+        this.orderNo = orderNo;
+    }
+
+    public BigDecimal getTotalAmount() {
+        return totalAmount;
+    }
+
+    public void setTotalAmount(BigDecimal totalAmount) {
+        this.totalAmount = totalAmount;
+    }
+
+    public Integer getTotalQuantity() {
+        return totalQuantity;
+    }
+
+    public void setTotalQuantity(Integer totalQuantity) {
+        this.totalQuantity = totalQuantity;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getShippingAddress() {
+        return shippingAddress;
+    }
+
+    public void setShippingAddress(String shippingAddress) {
+        this.shippingAddress = shippingAddress;
+    }
+
+    public String getRecipientName() {
+        return recipientName;
+    }
+
+    public void setRecipientName(String recipientName) {
+        this.recipientName = recipientName;
+    }
+
+    public String getRecipientPhone() {
+        return recipientPhone;
+    }
+
+    public void setRecipientPhone(String recipientPhone) {
+        this.recipientPhone = recipientPhone;
+    }
+
+    public Date getOrderTime() {
+        return orderTime;
+    }
+
+    public void setOrderTime(Date orderTime) {
+        this.orderTime = orderTime;
+    }
+
+    public Date getPaymentTime() {
+        return paymentTime;
+    }
+
+    public void setPaymentTime(Date paymentTime) {
+        this.paymentTime = paymentTime;
+    }
+
+    public Date getShippingTime() {
+        return shippingTime;
+    }
+
+    public void setShippingTime(Date shippingTime) {
+        this.shippingTime = shippingTime;
+    }
+
+    public Date getDeliveryTime() {
+        return deliveryTime;
+    }
+
+    public void setDeliveryTime(Date deliveryTime) {
+        this.deliveryTime = deliveryTime;
+    }
+
+    public List<OrderItemDetailDTO> getOrderItems() {
+        return orderItems;
+    }
+
+    public void setOrderItems(List<OrderItemDetailDTO> orderItems) {
+        this.orderItems = orderItems;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/OrderItemDetailDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/OrderItemDetailDTO.java
@@ -1,0 +1,91 @@
+package com.example.silkmall.dto;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+public class OrderItemDetailDTO {
+    private Long id;
+    private Integer quantity;
+    private BigDecimal unitPrice;
+    private BigDecimal totalPrice;
+    private Date createdAt;
+    private OrderedProductDTO product;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public BigDecimal getUnitPrice() {
+        return unitPrice;
+    }
+
+    public void setUnitPrice(BigDecimal unitPrice) {
+        this.unitPrice = unitPrice;
+    }
+
+    public BigDecimal getTotalPrice() {
+        return totalPrice;
+    }
+
+    public void setTotalPrice(BigDecimal totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OrderedProductDTO getProduct() {
+        return product;
+    }
+
+    public void setProduct(OrderedProductDTO product) {
+        this.product = product;
+    }
+
+    public static class OrderedProductDTO {
+        private Long id;
+        private String name;
+        private String mainImage;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getMainImage() {
+            return mainImage;
+        }
+
+        public void setMainImage(String mainImage) {
+            this.mainImage = mainImage;
+        }
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/UpdateOrderContactDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/UpdateOrderContactDTO.java
@@ -1,0 +1,31 @@
+package com.example.silkmall.dto;
+
+public class UpdateOrderContactDTO {
+    private String shippingAddress;
+    private String recipientName;
+    private String recipientPhone;
+
+    public String getShippingAddress() {
+        return shippingAddress;
+    }
+
+    public void setShippingAddress(String shippingAddress) {
+        this.shippingAddress = shippingAddress;
+    }
+
+    public String getRecipientName() {
+        return recipientName;
+    }
+
+    public void setRecipientName(String recipientName) {
+        this.recipientName = recipientName;
+    }
+
+    public String getRecipientPhone() {
+        return recipientPhone;
+    }
+
+    public void setRecipientPhone(String recipientPhone) {
+        this.recipientPhone = recipientPhone;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/repository/OrderRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/OrderRepository.java
@@ -3,9 +3,12 @@ package com.example.silkmall.repository;
 import com.example.silkmall.entity.Order;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
@@ -13,4 +16,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Page<Order> findByStatus(String status, Pageable pageable);
     List<Order> findByOrderNo(String orderNo);
     List<Order> findByConsumerLookupId(String consumerLookupId);
+
+    @EntityGraph(attributePaths = {"orderItems", "orderItems.product"})
+    Optional<Order> findDetailedById(Long id);
 }

--- a/backend/src/main/java/com/example/silkmall/service/OrderService.java
+++ b/backend/src/main/java/com/example/silkmall/service/OrderService.java
@@ -17,4 +17,5 @@ public interface OrderService extends BaseService<Order, Long> {
     void shipOrder(Long id);
     void deliverOrder(Long id);
     Order findOrderDetail(Long id);
+    Order updateContactInfo(Long id, String shippingAddress, String recipientName, String recipientPhone);
 }

--- a/backend/src/main/java/com/example/silkmall/service/impl/OrderServiceImpl.java
+++ b/backend/src/main/java/com/example/silkmall/service/impl/OrderServiceImpl.java
@@ -216,9 +216,7 @@ public class OrderServiceImpl extends BaseServiceImpl<Order, Long> implements Or
 
     @Override
     public Order findOrderDetail(Long id) {
-        // 这里可以返回包含订单项和产品详情的完整订单信息
-        // 实际项目中可能需要使用@EntityGraph或DTO来优化查询
-        return findById(id)
+        return orderRepository.findDetailedById(id)
                 .orElseThrow(() -> new RuntimeException("订单不存在"));
     }
     

--- a/backend/src/main/java/com/example/silkmall/service/impl/OrderServiceImpl.java
+++ b/backend/src/main/java/com/example/silkmall/service/impl/OrderServiceImpl.java
@@ -187,20 +187,33 @@ public class OrderServiceImpl extends BaseServiceImpl<Order, Long> implements Or
     public void deliverOrder(Long id) {
         Order order = findById(id)
                 .orElseThrow(() -> new RuntimeException("订单不存在"));
-        
+
         if (!"SHIPPING".equals(order.getStatus())) {
             throw new RuntimeException("只有运输中的订单才能确认收货");
         }
-        
+
         order.setStatus("DELIVERED");
         order.setDeliveryTime(new Date());
-        
+
         orderRepository.save(order);
-        
+
         // 订单完成后，可以增加产品销量和消费者积分
         // 这里简化处理，实际项目中可能需要更复杂的逻辑
     }
-    
+
+    @Transactional
+    @Override
+    public Order updateContactInfo(Long id, String shippingAddress, String recipientName, String recipientPhone) {
+        Order order = findById(id)
+                .orElseThrow(() -> new RuntimeException("订单不存在"));
+
+        order.setShippingAddress(shippingAddress);
+        order.setRecipientName(recipientName);
+        order.setRecipientPhone(recipientPhone);
+
+        return orderRepository.save(order);
+    }
+
     @Override
     public Order findOrderDetail(Long id) {
         // 这里可以返回包含订单项和产品详情的完整订单信息

--- a/silkmall-frontend/src/components/ProductCard.vue
+++ b/silkmall-frontend/src/components/ProductCard.vue
@@ -6,7 +6,12 @@ const props = defineProps<{ product: ProductSummary }>()
 
 const emit = defineEmits<{
   (e: 'purchase', product: ProductSummary): void
+  (e: 'view-detail', product: ProductSummary): void
 }>()
+
+function openDetail() {
+  emit('view-detail', props.product)
+}
 
 const statusLabel = computed(() => {
   const labelMap: Record<string, string> = {
@@ -32,7 +37,15 @@ const formattedPrice = computed(() =>
 </script>
 
 <template>
-  <article class="product-card">
+  <article
+    class="product-card"
+    role="button"
+    tabindex="0"
+    :aria-label="`查看商品详情：${product.name}`"
+    @click="openDetail"
+    @keydown.enter.prevent.stop="openDetail"
+    @keydown.space.prevent.stop="openDetail"
+  >
     <div class="media">
       <div class="image-frame" role="img" :aria-label="product.name">
         <img v-if="product.mainImage" :src="product.mainImage" :alt="product.name" loading="lazy" />
@@ -69,7 +82,7 @@ const formattedPrice = computed(() =>
           type="button"
           class="buy"
           :disabled="product.status !== 'ON_SALE' || product.stock <= 1"
-          @click="emit('purchase', product)"
+          @click.stop="emit('purchase', product)"
         >
           {{ product.status === 'ON_SALE' && product.stock > 1 ? '点击购买' : '暂不可购' }}
         </button>
@@ -89,11 +102,17 @@ const formattedPrice = computed(() =>
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
   backdrop-filter: blur(6px);
   transition: transform 0.25s ease, box-shadow 0.25s ease;
+  cursor: pointer;
 }
 
 .product-card:hover {
   transform: translateY(-6px);
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+}
+
+.product-card:focus-visible {
+  outline: 3px solid rgba(111, 169, 173, 0.65);
+  outline-offset: 4px;
 }
 
 .media {

--- a/silkmall-frontend/src/router/index.ts
+++ b/silkmall-frontend/src/router/index.ts
@@ -10,6 +10,7 @@ const SupplierWorkbench = () => import('../views/dashboard/SupplierWorkbench.vue
 const AdminOverview = () => import('../views/dashboard/AdminOverview.vue')
 const AdminConsumerManagement = () => import('../views/dashboard/AdminConsumerManagement.vue')
 const AdminProductManagement = () => import('../views/dashboard/AdminProductManagement.vue')
+const ProductDetailView = () => import('../views/ProductDetailView.vue')
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -26,6 +27,11 @@ const router = createRouter({
       // this generates a separate chunk (About.[hash].js) for this route
       // which is lazy-loaded when the route is visited.
       component: () => import('../views/AboutView.vue'),
+    },
+    {
+      path: '/product/:id',
+      name: 'product-detail',
+      component: ProductDetailView,
     },
     {
       path: '/orders',

--- a/silkmall-frontend/src/types/index.ts
+++ b/silkmall-frontend/src/types/index.ts
@@ -20,6 +20,30 @@ export interface ProductSummary {
   supplierLevel?: string | null
 }
 
+export interface ProductImage {
+  id: number
+  imageUrl: string
+  sortOrder?: number | null
+  createdAt?: string | null
+}
+
+export interface ProductDetail extends ProductSummary {
+  updatedAt?: string | null
+  images?: ProductImage[] | null
+  category?: {
+    id: number
+    name: string
+    description?: string | null
+  } | null
+  supplier?: {
+    id: number
+    companyName: string
+    supplierLevel?: string | null
+    contactName?: string | null
+    contactPhone?: string | null
+  } | null
+}
+
 export interface PurchaseOrderItemPayload {
   product: {
     id: number

--- a/silkmall-frontend/src/views/HomeView.vue
+++ b/silkmall-frontend/src/views/HomeView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 import ProductCard from '@/components/ProductCard.vue'
 import PurchaseDialog from '@/components/PurchaseDialog.vue'
 import api from '@/services/api'
@@ -48,6 +48,7 @@ const pageSize = ref(12)
 const purchaseTarget = ref<ProductSummary | null>(null)
 const purchaseSuccessMessage = ref<string | null>(null)
 const purchaseMessageTimer = ref<number | null>(null)
+const router = useRouter()
 
 const statusOptions = [
   { label: '全部状态', value: 'all' },
@@ -257,6 +258,10 @@ function handlePurchaseSuccess(order: PurchaseOrderResult) {
   fetchProducts()
 }
 
+function goToProductDetail(product: ProductSummary) {
+  router.push({ name: 'product-detail', params: { id: product.id } })
+}
+
 onMounted(async () => {
   pagination.size = pageSize.value
   await Promise.all([fetchOverview(), fetchCategories(), fetchSuppliers(), fetchHomepageContent()])
@@ -426,7 +431,13 @@ onBeforeUnmount(() => {
       <div v-else-if="emptyState" class="empty">暂无符合条件的商品，尝试调整筛选条件。</div>
 
       <div v-if="!loading && !emptyState" class="grid">
-        <ProductCard v-for="item in products" :key="item.id" :product="item" @purchase="openPurchaseDialog" />
+        <ProductCard
+          v-for="item in products"
+          :key="item.id"
+          :product="item"
+          @purchase="openPurchaseDialog"
+          @view-detail="goToProductDetail"
+        />
       </div>
 
       <div v-if="pagination.totalPages > 1" class="pagination" role="navigation" aria-label="分页导航">

--- a/silkmall-frontend/src/views/ProductDetailView.vue
+++ b/silkmall-frontend/src/views/ProductDetailView.vue
@@ -1,0 +1,583 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter, RouterLink } from 'vue-router'
+import api from '@/services/api'
+import type { ProductDetail } from '@/types'
+
+const route = useRoute()
+const router = useRouter()
+const product = ref<ProductDetail | null>(null)
+const loading = ref(false)
+const error = ref<string | null>(null)
+const activeImageIndex = ref(0)
+
+const statusLabel = computed(() => {
+  const labelMap: Record<string, string> = {
+    ON_SALE: '上架中',
+    OFF_SALE: '已下架',
+  }
+  return product.value?.status ? labelMap[product.value.status] ?? product.value.status : '未知状态'
+})
+
+const statusClass = computed(() => {
+  const map: Record<string, string> = {
+    ON_SALE: 'is-online',
+    OFF_SALE: 'is-offline',
+  }
+  return product.value?.status ? map[product.value.status] ?? 'is-default' : 'is-default'
+})
+
+const formattedPrice = computed(() => {
+  if (!product.value) {
+    return '--'
+  }
+  return new Intl.NumberFormat('zh-CN', { style: 'currency', currency: 'CNY' }).format(product.value.price)
+})
+
+const galleryImages = computed(() => {
+  if (!product.value) {
+    return [] as { id: string; url: string }[]
+  }
+  const images: { id: string; url: string }[] = []
+  if (product.value.mainImage) {
+    images.push({ id: 'main', url: product.value.mainImage })
+  }
+  const extras = product.value.images?.filter((img) => Boolean(img?.imageUrl)) ?? []
+  extras
+    .filter((img) => img.imageUrl !== product.value?.mainImage)
+    .forEach((img, index) => {
+      images.push({ id: `extra-${img.id ?? index}`, url: img.imageUrl! })
+    })
+  return images
+})
+
+const activeImage = computed(() => galleryImages.value[activeImageIndex.value] ?? null)
+
+const hasGallery = computed(() => galleryImages.value.length > 0)
+
+const fallbackLetter = computed(() => product.value?.name?.charAt(0)?.toUpperCase() ?? '丝')
+
+const createdAtText = computed(() => {
+  if (!product.value?.createdAt) {
+    return null
+  }
+  try {
+    return new Intl.DateTimeFormat('zh-CN', { dateStyle: 'medium', timeStyle: 'short' }).format(
+      new Date(product.value.createdAt)
+    )
+  } catch (err) {
+    return product.value.createdAt
+  }
+})
+
+const updatedAtText = computed(() => {
+  if (!product.value?.updatedAt) {
+    return null
+  }
+  try {
+    return new Intl.DateTimeFormat('zh-CN', { dateStyle: 'medium', timeStyle: 'short' }).format(
+      new Date(product.value.updatedAt)
+    )
+  } catch (err) {
+    return product.value.updatedAt
+  }
+})
+
+watch(
+  () => galleryImages.value.length,
+  (length) => {
+    if (length === 0) {
+      activeImageIndex.value = 0
+      return
+    }
+    if (activeImageIndex.value >= length) {
+      activeImageIndex.value = 0
+    }
+  },
+  { immediate: true }
+)
+
+async function loadProduct(idParam: string | string[]) {
+  const idValue = Array.isArray(idParam) ? idParam[0] : idParam
+  const numericId = Number.parseInt(idValue ?? '', 10)
+  if (!Number.isFinite(numericId) || numericId <= 0) {
+    error.value = '无法识别的商品编号'
+    product.value = null
+    return
+  }
+
+  loading.value = true
+  error.value = null
+
+  try {
+    const { data } = await api.get<ProductDetail>(`/products/${numericId}`)
+    product.value = data
+    activeImageIndex.value = 0
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : '加载商品信息失败'
+    product.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+function retry() {
+  loadProduct(route.params.id)
+}
+
+function setActiveImage(index: number) {
+  if (index >= 0 && index < galleryImages.value.length) {
+    activeImageIndex.value = index
+  }
+}
+
+function goBack() {
+  router.back()
+}
+
+onMounted(() => {
+  loadProduct(route.params.id)
+})
+
+watch(
+  () => route.params.id,
+  (id, oldId) => {
+    if (id !== oldId) {
+      loadProduct(id)
+    }
+  }
+)
+</script>
+
+<template>
+  <section class="product-detail">
+    <div class="page-container">
+      <nav class="breadcrumb" aria-label="面包屑导航">
+        <RouterLink to="/">产品中心</RouterLink>
+        <span aria-hidden="true">/</span>
+        <span>{{ product?.name ?? '商品详情' }}</span>
+      </nav>
+
+      <div v-if="loading" class="state-card">
+        <p>正在加载商品信息，请稍候...</p>
+      </div>
+
+      <div v-else-if="error" class="state-card is-error">
+        <p>{{ error }}</p>
+        <div class="actions">
+          <button type="button" @click="retry">重试</button>
+          <RouterLink to="/">返回产品中心</RouterLink>
+        </div>
+      </div>
+
+      <article v-else-if="product" class="detail-card">
+        <header class="detail-header">
+          <button type="button" class="back" @click="goBack">返回上一页</button>
+          <span class="status" :class="statusClass">{{ statusLabel }}</span>
+        </header>
+
+        <div class="detail-body">
+          <div class="gallery" aria-label="商品图片预览">
+            <div class="main-image" role="img" :aria-label="product.name">
+              <img v-if="hasGallery && activeImage" :src="activeImage.url" :alt="product.name" loading="lazy" />
+              <span v-else class="placeholder">{{ fallbackLetter }}</span>
+            </div>
+            <ul v-if="hasGallery" class="thumbnail-list" role="list">
+              <li v-for="(img, index) in galleryImages" :key="img.id">
+                <button
+                  type="button"
+                  :class="['thumbnail', { active: index === activeImageIndex }]"
+                  @click="setActiveImage(index)"
+                >
+                  <img :src="img.url" :alt="`${product.name} 图片 ${index + 1}`" loading="lazy" />
+                </button>
+              </li>
+            </ul>
+          </div>
+
+          <div class="info">
+            <h1>{{ product.name }}</h1>
+            <p class="price">{{ formattedPrice }}</p>
+            <p class="description">{{ product.description || '这款蚕制品暂未填写详细介绍。' }}</p>
+
+            <dl class="meta">
+              <div>
+                <dt>分类</dt>
+                <dd>{{ product.category?.name ?? '未分类' }}</dd>
+              </div>
+              <div>
+                <dt>供应商</dt>
+                <dd>
+                  {{ product.supplier?.companyName ?? '暂未关联供应商' }}
+                  <template v-if="product.supplier?.supplierLevel">（{{ product.supplier.supplierLevel }}）</template>
+                </dd>
+              </div>
+              <div v-if="product.supplier?.contactName || product.supplier?.contactPhone">
+                <dt>联系人</dt>
+                <dd>
+                  {{ product.supplier?.contactName ?? '暂无联系人' }}
+                  <template v-if="product.supplier?.contactPhone">（{{ product.supplier.contactPhone }}）</template>
+                </dd>
+              </div>
+              <div v-if="createdAtText">
+                <dt>创建时间</dt>
+                <dd>{{ createdAtText }}</dd>
+              </div>
+              <div v-if="updatedAtText">
+                <dt>最近更新</dt>
+                <dd>{{ updatedAtText }}</dd>
+              </div>
+            </dl>
+
+            <div class="stats">
+              <div>
+                <span class="label">库存</span>
+                <span class="value">{{ product.stock }}</span>
+              </div>
+              <div>
+                <span class="label">累计销量</span>
+                <span class="value">{{ product.sales }}</span>
+              </div>
+              <div>
+                <span class="label">状态</span>
+                <span class="value">{{ statusLabel }}</span>
+              </div>
+            </div>
+
+            <div class="cta">
+              <RouterLink class="purchase" to="/">返回产品中心</RouterLink>
+            </div>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.product-detail {
+  padding: 3rem 1.5rem 4rem;
+  background: linear-gradient(180deg, rgba(255, 250, 245, 0.9), rgba(255, 255, 255, 0.6));
+  min-height: 100vh;
+}
+
+.page-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: rgba(17, 24, 39, 0.6);
+}
+
+.breadcrumb a {
+  color: #6f9aa9;
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.state-card {
+  padding: 2rem;
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  text-align: center;
+  color: rgba(17, 24, 39, 0.7);
+}
+
+.state-card.is-error {
+  color: #b91c1c;
+}
+
+.state-card .actions {
+  margin-top: 1.25rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.state-card button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.5rem;
+  background: #f2b142;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.state-card button:hover {
+  background: #e3a235;
+}
+
+.state-card a {
+  color: #6f9aa9;
+}
+
+.detail-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 1.75rem;
+  box-shadow: 0 20px 48px rgba(15, 23, 42, 0.12);
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.detail-header .back {
+  border: none;
+  background: transparent;
+  color: #6f9aa9;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.25rem 0.5rem;
+}
+
+.detail-header .back:hover {
+  text-decoration: underline;
+}
+
+.status {
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  background: rgba(111, 154, 169, 0.12);
+  color: #0f172a;
+}
+
+.status.is-online {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.status.is-offline {
+  background: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+}
+
+.detail-body {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+}
+
+.gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.main-image {
+  position: relative;
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, rgba(242, 177, 66, 0.25), rgba(111, 169, 173, 0.35));
+  padding: 1rem;
+  display: grid;
+  place-items: center;
+  min-height: 320px;
+}
+
+.main-image img {
+  width: 100%;
+  max-height: 520px;
+  object-fit: contain;
+  border-radius: 1rem;
+}
+
+.placeholder {
+  font-size: 5rem;
+  font-weight: 700;
+  color: rgba(92, 44, 12, 0.7);
+}
+
+.thumbnail-list {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.thumbnail {
+  border: none;
+  padding: 0;
+  background: transparent;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.15);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.thumbnail img {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+}
+
+.thumbnail:hover,
+.thumbnail.active {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 32px rgba(242, 177, 66, 0.28);
+}
+
+.info {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.info h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1c1c1e;
+}
+
+.price {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #c2410c;
+}
+
+.description {
+  font-size: 1rem;
+  line-height: 1.65;
+  color: rgba(17, 24, 39, 0.75);
+}
+
+.meta {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.meta dt {
+  font-size: 0.8rem;
+  color: rgba(17, 24, 39, 0.45);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.meta dd {
+  margin: 0.25rem 0 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+}
+
+.stats .label {
+  display: block;
+  font-size: 0.75rem;
+  color: rgba(17, 24, 39, 0.45);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.stats .value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.cta {
+  margin-top: 1rem;
+}
+
+.cta .purchase {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(242, 177, 66, 0.85), rgba(111, 169, 173, 0.9));
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta .purchase:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(242, 177, 66, 0.28);
+}
+
+@media (max-width: 960px) {
+  .detail-body {
+    grid-template-columns: 1fr;
+  }
+
+  .main-image {
+    min-height: 260px;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .product-detail {
+    background: linear-gradient(180deg, rgba(17, 24, 39, 0.9), rgba(17, 24, 39, 0.65));
+  }
+
+  .breadcrumb {
+    color: rgba(226, 232, 240, 0.7);
+  }
+
+  .breadcrumb a {
+    color: #8bc4d2;
+  }
+
+  .state-card,
+  .detail-card {
+    background: rgba(30, 41, 59, 0.75);
+    color: #e2e8f0;
+  }
+
+  .state-card button {
+    background: rgba(242, 177, 66, 0.85);
+  }
+
+  .status {
+    background: rgba(148, 163, 184, 0.25);
+    color: #e2e8f0;
+  }
+
+  .info h1,
+  .price,
+  .meta dd,
+  .stats .value {
+    color: #f9fafb;
+  }
+
+  .description,
+  .meta dt,
+  .stats .label {
+    color: rgba(226, 232, 240, 0.72);
+  }
+
+  .thumbnail {
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+  }
+}
+</style>

--- a/silkmall-frontend/src/views/dashboard/ConsumerDashboard.vue
+++ b/silkmall-frontend/src/views/dashboard/ConsumerDashboard.vue
@@ -408,7 +408,7 @@ const shortcutLinks = [
           <table v-if="orders.length" class="orders-table">
             <thead>
               <tr>
-                <th scope="col">订单编号</th>
+                <th scope="col" class="col-order-no">订单编号</th>
                 <th scope="col">金额</th>
                 <th scope="col">数量</th>
                 <th scope="col">状态</th>
@@ -418,7 +418,7 @@ const shortcutLinks = [
             </thead>
             <tbody>
               <tr v-for="order in orders" :key="order.id">
-                <td>{{ order.orderNo }}</td>
+                <td class="col-order-no">{{ order.orderNo }}</td>
                 <td>{{ formatCurrency(order.totalAmount) }}</td>
                 <td>{{ order.totalQuantity }}</td>
                 <td><span class="status-pill">{{ order.status }}</span></td>
@@ -802,6 +802,12 @@ const shortcutLinks = [
   width: 100%;
   border-collapse: collapse;
   font-size: 0.95rem;
+}
+
+.orders-table .col-order-no {
+  max-width: 12rem;
+  word-break: break-all;
+  overflow-wrap: anywhere;
 }
 
 .orders-table th,

--- a/silkmall-frontend/src/views/dashboard/ConsumerDashboard.vue
+++ b/silkmall-frontend/src/views/dashboard/ConsumerDashboard.vue
@@ -710,7 +710,12 @@ const shortcutLinks = [
 .grid {
   display: grid;
   gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: stretch;
+}
+
+.panel.orders {
+  grid-column: 1 / -1;
 }
 
 .panel {
@@ -801,20 +806,20 @@ const shortcutLinks = [
 .orders-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.88rem;
+  font-size: 0.95rem;
 }
 
 .orders-table .col-order-no {
-  max-width: 14rem;
-  font-size: 0.85rem;
-  line-height: 1.35;
+  max-width: 22rem;
+  font-size: 0.96rem;
+  line-height: 1.45;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
 .orders-table th,
 .orders-table td {
-  padding: 0.6rem 0.35rem;
+  padding: 0.75rem 0.6rem;
   text-align: left;
 }
 
@@ -1099,15 +1104,16 @@ const shortcutLinks = [
 
 .product-grid {
   display: grid;
-  gap: 1.2rem;
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .product-card {
   border-radius: 16px;
   border: 1px solid rgba(79, 70, 229, 0.15);
-  padding: 1rem;
+  padding: 1.35rem;
   display: grid;
-  gap: 0.85rem;
+  gap: 1rem;
   background: rgba(255, 255, 255, 0.95);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -1118,14 +1124,15 @@ const shortcutLinks = [
 }
 
 .product-card h3 {
-  font-size: 0.98rem;
+  font-size: 1.1rem;
   font-weight: 700;
   color: rgba(17, 24, 39, 0.85);
 }
 
 .product-card p {
   color: rgba(17, 24, 39, 0.58);
-  font-size: 0.86rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
 }
 
 .product-card footer {

--- a/silkmall-frontend/src/views/dashboard/ConsumerDashboard.vue
+++ b/silkmall-frontend/src/views/dashboard/ConsumerDashboard.vue
@@ -177,7 +177,7 @@ async function fetchOrderDetail(orderId: number) {
   orderDetailLoading.value = true
   orderDetailError.value = null
   try {
-    const { data } = await api.get<OrderDetail>(`/orders/${orderId}`)
+    const { data } = await api.get<OrderDetail>(`/orders/${orderId}/detail`)
     orderDetail.value = data
     syncOrderSummary(data)
     return data

--- a/silkmall-frontend/src/views/dashboard/ConsumerDashboard.vue
+++ b/silkmall-frontend/src/views/dashboard/ConsumerDashboard.vue
@@ -801,18 +801,20 @@ const shortcutLinks = [
 .orders-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.95rem;
+  font-size: 0.88rem;
 }
 
 .orders-table .col-order-no {
-  max-width: 12rem;
-  word-break: break-all;
+  max-width: 14rem;
+  font-size: 0.85rem;
+  line-height: 1.35;
   overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .orders-table th,
 .orders-table td {
-  padding: 0.75rem 0.5rem;
+  padding: 0.6rem 0.35rem;
   text-align: left;
 }
 
@@ -1103,9 +1105,9 @@ const shortcutLinks = [
 .product-card {
   border-radius: 16px;
   border: 1px solid rgba(79, 70, 229, 0.15);
-  padding: 1.2rem;
+  padding: 1rem;
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
   background: rgba(255, 255, 255, 0.95);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -1116,14 +1118,14 @@ const shortcutLinks = [
 }
 
 .product-card h3 {
-  font-size: 1.05rem;
+  font-size: 0.98rem;
   font-weight: 700;
   color: rgba(17, 24, 39, 0.85);
 }
 
 .product-card p {
   color: rgba(17, 24, 39, 0.58);
-  font-size: 0.92rem;
+  font-size: 0.86rem;
 }
 
 .product-card footer {

--- a/silkmall-frontend/src/views/dashboard/ConsumerDashboard.vue
+++ b/silkmall-frontend/src/views/dashboard/ConsumerDashboard.vue
@@ -71,6 +71,8 @@ const orderUpdateForm = reactive({
 })
 
 const orderItems = computed<OrderItemDetail[]>(() => orderDetail.value?.orderItems ?? [])
+const hasRecommendations = computed(() => (homeContent.value?.recommendations?.length ?? 0) > 0)
+const hasAnnouncements = computed(() => announcements.value.length > 0)
 
 async function loadProfile() {
   if (!state.user) return
@@ -355,34 +357,38 @@ const shortcutLinks = [
     <div v-else-if="error" class="placeholder is-error">{{ error }}</div>
     <template v-else>
       <div class="grid">
-        <section class="panel profile" aria-labelledby="profile-title">
+        <section class="panel profile full-row table-panel" aria-labelledby="profile-title">
           <div class="panel-title" id="profile-title">账户信息</div>
-          <ul class="profile-list">
-            <li>
-              <span>邮箱</span>
-              <strong>{{ profile?.email ?? '—' }}</strong>
-            </li>
-            <li>
-              <span>联系电话</span>
-              <strong>{{ profile?.phone ?? '—' }}</strong>
-            </li>
-            <li>
-              <span>收货地址</span>
-              <strong>{{ profile?.address ?? '尚未填写' }}</strong>
-            </li>
-            <li>
-              <span>会员等级</span>
-              <strong>{{ membershipBadge(profile?.membershipLevel) }}</strong>
-            </li>
-            <li>
-              <span>积分</span>
-              <strong>{{ profile?.points ?? 0 }}</strong>
-            </li>
-            <li>
-              <span>钱包余额</span>
-              <strong>{{ formatCurrency(walletBalance ?? 0) }}</strong>
-            </li>
-          </ul>
+          <div class="table-container">
+            <table class="dashboard-table profile-table">
+              <tbody>
+                <tr>
+                  <th scope="row">邮箱</th>
+                  <td>{{ profile?.email ?? '—' }}</td>
+                </tr>
+                <tr>
+                  <th scope="row">联系电话</th>
+                  <td>{{ profile?.phone ?? '—' }}</td>
+                </tr>
+                <tr>
+                  <th scope="row">收货地址</th>
+                  <td>{{ profile?.address ?? '尚未填写' }}</td>
+                </tr>
+                <tr>
+                  <th scope="row">会员等级</th>
+                  <td>{{ membershipBadge(profile?.membershipLevel) }}</td>
+                </tr>
+                <tr>
+                  <th scope="row">积分</th>
+                  <td>{{ profile?.points ?? 0 }}</td>
+                </tr>
+                <tr>
+                  <th scope="row">钱包余额</th>
+                  <td>{{ formatCurrency(walletBalance ?? 0) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
           <div class="redeem-box">
             <label>
               <span>兑换码</span>
@@ -403,70 +409,99 @@ const shortcutLinks = [
           </div>
         </section>
 
-        <section class="panel orders" aria-labelledby="orders-title">
+        <section class="panel orders full-row table-panel" aria-labelledby="orders-title">
           <div class="panel-title" id="orders-title">最近订单</div>
-          <table v-if="orders.length" class="orders-table">
-            <thead>
-              <tr>
-                <th scope="col" class="col-order-no">订单编号</th>
-                <th scope="col">金额</th>
-                <th scope="col">数量</th>
-                <th scope="col">状态</th>
-                <th scope="col">下单时间</th>
-                <th scope="col" class="col-actions">操作</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="order in orders" :key="order.id">
-                <td class="col-order-no">{{ order.orderNo }}</td>
-                <td>{{ formatCurrency(order.totalAmount) }}</td>
-                <td>{{ order.totalQuantity }}</td>
-                <td><span class="status-pill">{{ order.status }}</span></td>
-                <td>{{ formatDateTime(order.orderTime) }}</td>
-                <td class="actions-cell">
-                  <button type="button" class="link-button" @click="openOrderDetail(order)">
-                    查看订单
-                  </button>
-                  <button type="button" class="link-button" @click="openReturnDialog(order)">
-                    申请退货
-                  </button>
-                  <button type="button" class="link-button" @click="openEditDialog(order)">
-                    更改信息
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+          <div v-if="orders.length" class="table-container">
+            <table class="dashboard-table orders-table">
+              <thead>
+                <tr>
+                  <th scope="col" class="col-order-no">订单编号</th>
+                  <th scope="col">金额</th>
+                  <th scope="col">数量</th>
+                  <th scope="col">状态</th>
+                  <th scope="col">下单时间</th>
+                  <th scope="col" class="col-actions">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="order in orders" :key="order.id">
+                  <td class="col-order-no">{{ order.orderNo }}</td>
+                  <td>{{ formatCurrency(order.totalAmount) }}</td>
+                  <td>{{ order.totalQuantity }}</td>
+                  <td><span class="status-pill">{{ order.status }}</span></td>
+                  <td>{{ formatDateTime(order.orderTime) }}</td>
+                  <td class="actions-cell">
+                    <button type="button" class="link-button" @click="openOrderDetail(order)">
+                      查看订单
+                    </button>
+                    <button type="button" class="link-button" @click="openReturnDialog(order)">
+                      申请退货
+                    </button>
+                    <button type="button" class="link-button" @click="openEditDialog(order)">
+                      更改信息
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
           <p v-else class="empty">暂无订单记录，前往首页挑选心仪商品吧。</p>
         </section>
 
-        <section class="panel recommendations" aria-labelledby="recommend-title">
+        <section class="panel recommendations full-row table-panel" aria-labelledby="recommend-title">
           <div class="panel-title" id="recommend-title">为您推荐</div>
-          <div class="product-grid">
-            <article v-for="item in homeContent?.recommendations ?? []" :key="item.id" class="product-card">
-              <div class="product-meta">
-                <h3>{{ item.name }}</h3>
-                <p>{{ item.description ?? '优质蚕丝，严选供应链品质保障。' }}</p>
-              </div>
-              <footer>
-                <span class="price">{{ formatCurrency(item.price) }}</span>
-                <router-link :to="`/product/${item.id}`">查看详情</router-link>
-              </footer>
-            </article>
+          <div v-if="hasRecommendations" class="table-container">
+            <table class="dashboard-table recommend-table">
+              <thead>
+                <tr>
+                  <th scope="col">商品信息</th>
+                  <th scope="col" class="col-price">价格</th>
+                  <th scope="col" class="col-actions">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in homeContent?.recommendations ?? []" :key="item.id">
+                  <td>
+                    <div class="product-info">
+                      <strong>{{ item.name }}</strong>
+                      <p>{{ item.description ?? '优质蚕丝，严选供应链品质保障。' }}</p>
+                    </div>
+                  </td>
+                  <td class="col-price">{{ formatCurrency(item.price) }}</td>
+                  <td class="actions-cell">
+                    <router-link class="link-button" :to="`/product/${item.id}`">查看详情</router-link>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
+          <p v-else class="empty">暂无推荐商品，稍后再来看看吧。</p>
         </section>
 
-        <section class="panel announcements" aria-labelledby="announcement-title">
+        <section class="panel announcements full-row table-panel" aria-labelledby="announcement-title">
           <div class="panel-title" id="announcement-title">公告与资讯</div>
-          <ul class="announcement-list">
-            <li v-for="item in announcements" :key="item.id">
-              <div>
-                <strong>{{ item.title }}</strong>
-                <p>{{ item.content }}</p>
-              </div>
-              <time>{{ formatDateTime(item.publishedAt) }}</time>
-            </li>
-          </ul>
+          <div v-if="hasAnnouncements" class="table-container">
+            <table class="dashboard-table announcement-table">
+              <thead>
+                <tr>
+                  <th scope="col">公告内容</th>
+                  <th scope="col" class="col-time">发布时间</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in announcements" :key="item.id">
+                  <td>
+                    <div class="announcement-info">
+                      <strong>{{ item.title }}</strong>
+                      <p>{{ item.content }}</p>
+                    </div>
+                  </td>
+                  <td class="col-time">{{ formatDateTime(item.publishedAt) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p v-else class="empty">暂无公告，敬请期待更多平台动态。</p>
         </section>
       </div>
     </template>
@@ -710,12 +745,8 @@ const shortcutLinks = [
 .grid {
   display: grid;
   gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
   align-items: stretch;
-}
-
-.panel.orders {
-  grid-column: 1 / -1;
 }
 
 .panel {
@@ -728,36 +759,75 @@ const shortcutLinks = [
   box-shadow: 0 20px 40px rgba(31, 41, 55, 0.08);
 }
 
+.full-row {
+  grid-column: 1 / -1;
+}
+
+.table-panel {
+  gap: 1.75rem;
+}
+
 .panel-title {
   font-weight: 700;
   font-size: 1.1rem;
   color: rgba(17, 24, 39, 0.78);
 }
 
-.profile-list {
-  list-style: none;
-  display: grid;
-  gap: 0.85rem;
-  padding: 0;
+.table-container {
+  border-radius: 18px;
+  border: 1px solid rgba(79, 70, 229, 0.12);
+  overflow: hidden;
+  overflow-x: auto;
+  background: rgba(248, 250, 252, 0.68);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
-.profile-list li {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+.dashboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  min-width: 100%;
+}
+
+.dashboard-table th,
+.dashboard-table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+}
+
+.dashboard-table thead {
+  background: rgba(79, 70, 229, 0.08);
+  color: rgba(17, 24, 39, 0.62);
+}
+
+.dashboard-table tbody tr {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.dashboard-table tbody tr:nth-child(odd) {
+  background: rgba(79, 70, 229, 0.06);
+}
+
+.dashboard-table tbody tr + tr {
+  border-top: 1px solid rgba(79, 70, 229, 0.08);
+}
+
+.profile-table th {
+  width: 160px;
+  font-weight: 600;
   color: rgba(17, 24, 39, 0.6);
 }
 
-.profile-list strong {
+.profile-table td {
   color: rgba(17, 24, 39, 0.85);
 }
 
 .redeem-box {
   display: grid;
-  gap: 0.75rem;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(17, 24, 39, 0.08);
+  gap: 0.85rem;
+  padding: 1.2rem 1.3rem;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(99, 102, 241, 0.08));
 }
 
 .redeem-box label {
@@ -803,12 +873,6 @@ const shortcutLinks = [
   color: #b91c1c;
 }
 
-.orders-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.95rem;
-}
-
 .orders-table .col-order-no {
   max-width: 22rem;
   font-size: 0.96rem;
@@ -817,21 +881,7 @@ const shortcutLinks = [
   word-break: break-word;
 }
 
-.orders-table th,
-.orders-table td {
-  padding: 0.75rem 0.6rem;
-  text-align: left;
-}
-
-.orders-table thead {
-  color: rgba(17, 24, 39, 0.55);
-}
-
-.orders-table tbody tr:nth-child(odd) {
-  background: rgba(79, 70, 229, 0.06);
-}
-
-.orders-table .col-actions {
+.dashboard-table .col-actions {
   text-align: right;
 }
 
@@ -843,6 +893,8 @@ const shortcutLinks = [
 }
 
 .link-button {
+  display: inline-flex;
+  align-items: center;
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
   border: 1px solid rgba(79, 70, 229, 0.25);
@@ -862,6 +914,50 @@ const shortcutLinks = [
 .link-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.recommend-table .product-info {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.recommend-table .product-info strong {
+  font-weight: 700;
+  color: rgba(17, 24, 39, 0.85);
+}
+
+.recommend-table .product-info p {
+  color: rgba(17, 24, 39, 0.6);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.recommend-table .col-price {
+  font-weight: 600;
+  color: #16a34a;
+  white-space: nowrap;
+  text-align: right;
+}
+
+.announcement-table .announcement-info {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.announcement-table .announcement-info strong {
+  font-weight: 700;
+  color: rgba(17, 24, 39, 0.78);
+}
+
+.announcement-table .announcement-info p {
+  color: rgba(17, 24, 39, 0.6);
+  line-height: 1.5;
+}
+
+.announcement-table .col-time {
+  white-space: nowrap;
+  color: rgba(17, 24, 39, 0.55);
+  text-align: right;
 }
 
 .status-pill {
@@ -1100,84 +1196,6 @@ const shortcutLinks = [
 
 .field textarea {
   min-height: 120px;
-}
-
-.product-grid {
-  display: grid;
-  gap: 1.6rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.product-card {
-  border-radius: 16px;
-  border: 1px solid rgba(79, 70, 229, 0.15);
-  padding: 1.35rem;
-  display: grid;
-  gap: 1rem;
-  background: rgba(255, 255, 255, 0.95);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.product-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 14px 30px rgba(79, 70, 229, 0.18);
-}
-
-.product-card h3 {
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: rgba(17, 24, 39, 0.85);
-}
-
-.product-card p {
-  color: rgba(17, 24, 39, 0.58);
-  font-size: 0.95rem;
-  line-height: 1.6;
-}
-
-.product-card footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-weight: 600;
-}
-
-.product-card .price {
-  color: #16a34a;
-}
-
-.product-card a {
-  color: #4f46e5;
-  text-decoration: none;
-}
-
-.announcement-list {
-  list-style: none;
-  padding: 0;
-  display: grid;
-  gap: 1.1rem;
-}
-
-.announcement-list li {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: flex-start;
-}
-
-.announcement-list strong {
-  display: block;
-  font-weight: 700;
-  margin-bottom: 0.25rem;
-}
-
-.announcement-list p {
-  color: rgba(17, 24, 39, 0.6);
-}
-
-.announcement-list time {
-  color: rgba(17, 24, 39, 0.45);
-  font-size: 0.85rem;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- make product cards accessible buttons that open a detail view without interfering with the purchase action
- add a typed product detail route and supporting API types for fetching extended product information
- implement a dedicated product detail page with gallery, metadata, and navigation back to the product center

## Testing
- npm run build *(fails: Vite requires Node.js 20.19+ in the current container and crypto.hash is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f7242fc4832eb30fcd658f2d5a25