### PR TITLE
Fix product modal overflow handling

### DIFF
--- a/silkmall-frontend/src/views/dashboard/AdminProductManagement.vue
+++ b/silkmall-frontend/src/views/dashboard/AdminProductManagement.vue
@@ -84,6 +84,8 @@ const statusOptions = [
   { value: 'OFF_SALE', label: '未上架' },
 ]
 
+const unitOptions = ['件', '条', '个', '箱']
+
 const totalPages = computed(() =>
   pagination.total > 0 ? Math.ceil(pagination.total / pagination.size) : 0
 )
@@ -649,7 +651,16 @@ async function changeProductStatus(productId: number, nextStatus: 'ON_SALE' | 'O
           </label>
           <label>
             <span>计量单位</span>
-            <input v-model="productForm.unit" type="text" placeholder="如：件 / 箱 / kg" maxlength="20" />
+            <input
+              v-model="productForm.unit"
+              type="text"
+              placeholder="如：件 / 箱 / kg"
+              maxlength="20"
+              list="admin-product-unit-options"
+            />
+            <datalist id="admin-product-unit-options">
+              <option v-for="option in unitOptions" :key="option" :value="option"></option>
+            </datalist>
           </label>
           <label>
             <span>库存数量</span>

--- a/silkmall-frontend/src/views/dashboard/AdminProductManagement.vue
+++ b/silkmall-frontend/src/views/dashboard/AdminProductManagement.vue
@@ -1048,6 +1048,7 @@ tbody tr:nth-child(odd) {
   justify-content: center;
   padding: 2rem;
   z-index: 20;
+  overflow-y: auto;
 }
 
 .form-shell {

--- a/silkmall-frontend/src/views/dashboard/SupplierWorkbench.vue
+++ b/silkmall-frontend/src/views/dashboard/SupplierWorkbench.vue
@@ -2072,6 +2072,7 @@ async function removeCategory(option: CategoryOption) {
   justify-content: center;
   padding: 1.5rem;
   z-index: 30;
+  overflow-y: auto;
 }
 
 .modal {
@@ -2081,6 +2082,9 @@ async function removeCategory(option: CategoryOption) {
   width: 100%;
   box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
   overflow: hidden;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .modal-header {
@@ -2096,6 +2100,8 @@ async function removeCategory(option: CategoryOption) {
   flex-direction: column;
   gap: 1rem;
   padding: 1.5rem;
+  flex: 1 1 auto;
+  overflow-y: auto;
 }
 
 .modal-body label {


### PR DESCRIPTION
## Summary
- allow the admin product modal overlay to scroll so actions stay reachable on small screens
- update the supplier product modal layout to support scrolling when large previews are shown

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_6909bb7d16f4832cb7df3360934b9134