### PR TITLE
Add admin supplier management navigation and route

### DIFF
--- a/backend/src/main/java/com/example/silkmall/repository/NewSupplierRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/NewSupplierRepository.java
@@ -2,12 +2,13 @@ package com.example.silkmall.repository;
 
 import com.example.silkmall.entity.Supplier;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface NewSupplierRepository extends JpaRepository<Supplier, Long> {
+public interface NewSupplierRepository extends JpaRepository<Supplier, Long>, JpaSpecificationExecutor<Supplier> {
     Optional<Supplier> findByUsername(String username);
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);

--- a/backend/src/main/java/com/example/silkmall/repository/SupplierRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/SupplierRepository.java
@@ -2,11 +2,12 @@ package com.example.silkmall.repository;
 
 import com.example.silkmall.entity.Supplier;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface SupplierRepository extends JpaRepository<Supplier, Long>, BaseUserRepository<Supplier> {
+public interface SupplierRepository extends JpaRepository<Supplier, Long>, BaseUserRepository<Supplier>, JpaSpecificationExecutor<Supplier> {
     List<Supplier> findByStatus(String status);
     List<Supplier> findBySupplierLevel(String level);
 }

--- a/backend/src/main/java/com/example/silkmall/service/SupplierService.java
+++ b/backend/src/main/java/com/example/silkmall/service/SupplierService.java
@@ -1,6 +1,8 @@
 package com.example.silkmall.service;
 
 import com.example.silkmall.entity.Supplier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface SupplierService extends UserService<Supplier> {
@@ -9,4 +11,6 @@ public interface SupplierService extends UserService<Supplier> {
     void approveSupplier(Long id);
     void rejectSupplier(Long id, String reason);
     void updateSupplierLevel(Long id, String level);
+
+    Page<Supplier> search(String keyword, String status, String level, Boolean enabled, Pageable pageable);
 }

--- a/silkmall-frontend/src/router/index.ts
+++ b/silkmall-frontend/src/router/index.ts
@@ -7,6 +7,7 @@ const ConsumerDashboard = () => import('../views/dashboard/ConsumerDashboard.vue
 const SupplierWorkbench = () => import('../views/dashboard/SupplierWorkbench.vue')
 const AdminOverview = () => import('../views/dashboard/AdminOverview.vue')
 const AdminConsumerManagement = () => import('../views/dashboard/AdminConsumerManagement.vue')
+const AdminSupplierManagement = () => import('../views/dashboard/AdminSupplierManagement.vue')
 const AdminProductManagement = () => import('../views/dashboard/AdminProductManagement.vue')
 const AdminOrderManagement = () => import('../views/dashboard/AdminOrderManagement.vue')
 const ProductDetailView = () => import('../views/ProductDetailView.vue')
@@ -83,6 +84,12 @@ const router = createRouter({
       path: '/admin/consumers',
       name: 'admin-consumers',
       component: AdminConsumerManagement,
+      meta: { requiresAuth: true, roles: ['admin'] },
+    },
+    {
+      path: '/admin/suppliers',
+      name: 'admin-suppliers',
+      component: AdminSupplierManagement,
       meta: { requiresAuth: true, roles: ['admin'] },
     },
   ],

--- a/silkmall-frontend/src/views/dashboard/AdminOverview.vue
+++ b/silkmall-frontend/src/views/dashboard/AdminOverview.vue
@@ -713,6 +713,7 @@ function formatNumber(value?: number | null) {
         <RouterLink class="manage-link" to="/admin/products">商品管理</RouterLink>
         <RouterLink class="manage-link" to="/admin/orders">订单管理</RouterLink>
         <RouterLink class="manage-link" to="/admin/consumers">采购账号管理</RouterLink>
+        <RouterLink class="manage-link" to="/admin/suppliers">供应商账号管理</RouterLink>
       </nav>
     </header>
 


### PR DESCRIPTION
## Summary
- add a dedicated admin route for supplier account management with proper auth metadata
- expose the supplier account management entry alongside existing admin navigation links

## Testing
- npm run build *(fails: existing type errors in src/views/LoginView.vue unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943e5189a2483309116807226092106)