### PR TITLE
Add weekly sales analytics for admin dashboard

### DIFF
--- a/backend/silkmall-frontend/src/types/index.ts
+++ b/backend/silkmall-frontend/src/types/index.ts
@@ -162,6 +162,34 @@ export interface ProductReview {
   createdAt: string
 }
 
+export interface WeeklyOrderDetail {
+  id: number
+  orderNo: string
+  totalAmount: number
+  totalQuantity: number
+  status: string
+  orderTime: string
+}
+
+export interface WeeklyProductPerformance {
+  productId: number | null
+  productName: string
+  supplierId: number | null
+  supplierName: string
+  quantitySold: number
+  totalRevenue: number
+}
+
+export interface WeeklySalesStatistics {
+  weekStart: string
+  weekEnd: string
+  orderCount: number
+  totalUnitsSold: number
+  totalSalesAmount: number
+  orders: WeeklyOrderDetail[]
+  productPerformances: WeeklyProductPerformance[]
+}
+
 export interface ReturnRequest {
   id: number
   orderId: number

--- a/backend/silkmall-frontend/src/views/dashboard/AdminOverview.vue
+++ b/backend/silkmall-frontend/src/views/dashboard/AdminOverview.vue
@@ -7,18 +7,30 @@ import type {
   NewsItem,
   ProductOverview,
   ProductSummary,
+  WeeklySalesStatistics,
 } from '@/types'
 
 const overview = ref<ProductOverview | null>(null)
 const announcements = ref<Announcement[]>([])
 const news = ref<NewsItem[]>([])
 const hotProducts = ref<ProductSummary[]>([])
+const weeklyStats = ref<WeeklySalesStatistics[]>([])
 const loading = ref(true)
 const error = ref<string | null>(null)
 
 async function loadOverview() {
   const { data } = await api.get<ProductOverview>('/products/overview')
   overview.value = data
+}
+
+async function loadWeeklySales() {
+  const { data } = await api.get<WeeklySalesStatistics[]>(
+    '/admins/analytics/weekly-sales',
+    {
+      params: { weeks: 6 },
+    }
+  )
+  weeklyStats.value = data
 }
 
 async function loadHomeContent() {
@@ -32,7 +44,7 @@ async function bootstrap() {
   loading.value = true
   error.value = null
   try {
-    await Promise.all([loadOverview(), loadHomeContent()])
+    await Promise.all([loadOverview(), loadHomeContent(), loadWeeklySales()])
   } catch (err) {
     error.value = err instanceof Error ? err.message : '加载管理数据失败'
   } finally {
@@ -47,6 +59,30 @@ onMounted(() => {
 function formatNumber(value?: number | null) {
   if (typeof value !== 'number' || Number.isNaN(value)) return '0'
   return new Intl.NumberFormat('zh-CN').format(value)
+}
+
+function formatCurrency(value?: number | null) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '0.00'
+  return new Intl.NumberFormat('zh-CN', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function formatWeekRange(start?: string, end?: string) {
+  if (!start || !end) return '本周'
+  const formatter = new Intl.DateTimeFormat('zh-CN', { month: '2-digit', day: '2-digit' })
+  return `${formatter.format(new Date(start))} - ${formatter.format(new Date(end))}`
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) return '--'
+  return new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(value))
 }
 </script>
 
@@ -86,6 +122,75 @@ function formatNumber(value?: number | null) {
             <strong>{{ formatNumber(overview?.totalSalesVolume) }}</strong>
           </div>
         </div>
+      </section>
+
+      <section class="panel weekly" aria-labelledby="weekly-title">
+        <div class="panel-title" id="weekly-title">每周销售数据</div>
+        <p class="panel-subtitle">按周拆分订单与商品表现，快速洞察销量走势与供应商贡献。</p>
+
+        <div v-if="weeklyStats.length" class="week-grid">
+          <article v-for="week in weeklyStats" :key="week.weekStart" class="week-card">
+            <header class="week-header">
+              <div>
+                <p class="week-range">{{ formatWeekRange(week.weekStart, week.weekEnd) }}</p>
+                <p class="week-meta">订单 {{ formatNumber(week.orderCount) }} · 件数 {{ formatNumber(week.totalUnitsSold) }}</p>
+              </div>
+              <div class="week-amount">¥{{ formatCurrency(week.totalSalesAmount) }}</div>
+            </header>
+
+            <div class="week-body">
+              <div class="subpanel">
+                <div class="subpanel-title">订单明细</div>
+                <table v-if="week.orders.length" class="compact">
+                  <thead>
+                    <tr>
+                      <th scope="col">订单号</th>
+                      <th scope="col">金额</th>
+                      <th scope="col">数量</th>
+                      <th scope="col">状态</th>
+                      <th scope="col">下单时间</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="order in week.orders" :key="order.id">
+                      <td class="mono">{{ order.orderNo }}</td>
+                      <td>¥{{ formatCurrency(order.totalAmount) }}</td>
+                      <td>{{ formatNumber(order.totalQuantity) }}</td>
+                      <td>{{ order.status }}</td>
+                      <td>{{ formatDateTime(order.orderTime) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p v-else class="empty muted">本周暂无订单。</p>
+              </div>
+
+              <div class="subpanel">
+                <div class="subpanel-title">商品表现（按供应商拆分）</div>
+                <table v-if="week.productPerformances.length" class="compact">
+                  <thead>
+                    <tr>
+                      <th scope="col">商品</th>
+                      <th scope="col">供应商</th>
+                      <th scope="col">销量</th>
+                      <th scope="col">销售额</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="item in week.productPerformances" :key="`${item.productId}-${item.supplierId}`">
+                      <td>{{ item.productName }}</td>
+                      <td>{{ item.supplierName }}</td>
+                      <td>{{ formatNumber(item.quantitySold) }}</td>
+                      <td>¥{{ formatCurrency(item.totalRevenue) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p v-else class="empty muted">暂无销售记录。</p>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <p v-else class="empty">暂无周度销售数据，等待订单积累后自动生成。</p>
       </section>
 
       <section class="panel hot-products" aria-labelledby="hot-title">
@@ -188,6 +293,12 @@ function formatNumber(value?: number | null) {
   color: rgba(30, 41, 59, 0.78);
 }
 
+.panel-subtitle {
+  margin-top: -0.5rem;
+  color: rgba(30, 41, 59, 0.6);
+  font-size: 0.95rem;
+}
+
 .metric-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -210,6 +321,107 @@ function formatNumber(value?: number | null) {
 .metric-grid strong {
   font-size: 1.4rem;
   font-weight: 700;
+}
+
+.weekly .panel-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.week-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.week-card {
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  border-radius: 16px;
+  padding: 1.2rem;
+  background: rgba(255, 255, 255, 0.85);
+  display: grid;
+  gap: 1rem;
+}
+
+.week-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.week-range {
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.week-meta {
+  color: rgba(15, 23, 42, 0.6);
+  margin-top: 0.2rem;
+}
+
+.week-amount {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: #f97316;
+}
+
+.week-body {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 900px) {
+  .week-body {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.subpanel {
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 12px;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.subpanel-title {
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.compact {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.compact th,
+.compact td {
+  padding: 0.35rem 0.55rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.compact th {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.compact td {
+  font-size: 0.9rem;
+}
+
+.compact tr:last-child td {
+  border-bottom: none;
+}
+
+.muted {
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.mono {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 }
 
 .hot-products table {

--- a/backend/silkmall-frontend/src/views/dashboard/AdminOverview.vue
+++ b/backend/silkmall-frontend/src/views/dashboard/AdminOverview.vue
@@ -7,6 +7,8 @@ import type {
   NewsItem,
   ProductOverview,
   ProductSummary,
+  WeeklyOrderDetail,
+  WeeklyProductPerformance,
   WeeklySalesStatistics,
 } from '@/types'
 
@@ -24,13 +26,18 @@ async function loadOverview() {
 }
 
 async function loadWeeklySales() {
-  const { data } = await api.get<WeeklySalesStatistics[]>(
-    '/admins/analytics/weekly-sales',
-    {
-      params: { weeks: 6 },
-    }
-  )
-  weeklyStats.value = data
+  try {
+    const { data } = await api.get<WeeklySalesStatistics[]>(
+      '/admins/analytics/weekly-sales',
+      {
+        params: { weeks: 6 },
+      }
+    )
+    weeklyStats.value = normaliseWeeklyStats(data)
+  } catch (err) {
+    console.warn('加载周销售数据失败', err)
+    weeklyStats.value = []
+  }
 }
 
 async function loadHomeContent() {
@@ -55,6 +62,91 @@ async function bootstrap() {
 onMounted(() => {
   bootstrap()
 })
+
+function normaliseWeeklyStats(payload: unknown): WeeklySalesStatistics[] {
+  if (!Array.isArray(payload)) {
+    return []
+  }
+
+  const coerceOrders = (raw: unknown): WeeklyOrderDetail[] => {
+    if (!Array.isArray(raw)) return []
+    return raw
+      .map((item) => {
+        if (!item || typeof item !== 'object') return null
+        const source = item as Record<string, unknown>
+        const id = Number(source.id)
+        const totalAmount = Number(source.totalAmount)
+        const totalQuantity = Number(source.totalQuantity)
+        const orderTime =
+          typeof source.orderTime === 'string' ? source.orderTime : String(source.orderTime ?? '')
+        return {
+          id: Number.isFinite(id) ? id : 0,
+          orderNo: typeof source.orderNo === 'string' ? source.orderNo : String(source.orderNo ?? ''),
+          totalAmount: Number.isFinite(totalAmount) ? totalAmount : 0,
+          totalQuantity: Number.isFinite(totalQuantity) ? totalQuantity : 0,
+          status: typeof source.status === 'string' ? source.status : '未知',
+          orderTime: orderTime || '',
+        }
+      })
+      .filter((item): item is WeeklyOrderDetail => !!item && !!item.orderNo)
+  }
+
+  const coercePerformance = (raw: unknown): WeeklyProductPerformance[] => {
+    if (!Array.isArray(raw)) return []
+    return raw
+      .map((item) => {
+        if (!item || typeof item !== 'object') return null
+        const source = item as Record<string, unknown>
+        const productId = Number(source.productId)
+        const supplierId = Number(source.supplierId)
+        const quantitySold = Number(source.quantitySold)
+        const totalRevenue = Number(source.totalRevenue)
+        return {
+          productId: Number.isFinite(productId) ? productId : null,
+          productName:
+            typeof source.productName === 'string'
+              ? source.productName
+              : String(source.productName ?? '未知商品'),
+          supplierId: Number.isFinite(supplierId) ? supplierId : null,
+          supplierName:
+            typeof source.supplierName === 'string'
+              ? source.supplierName
+              : String(source.supplierName ?? '未知供应商'),
+          quantitySold: Number.isFinite(quantitySold) ? quantitySold : 0,
+          totalRevenue: Number.isFinite(totalRevenue) ? totalRevenue : 0,
+        }
+      })
+      .filter((item): item is WeeklyProductPerformance => !!item)
+  }
+
+  return payload
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null
+      const source = item as Record<string, unknown>
+      const orders = coerceOrders(source.orders)
+      const performances = coercePerformance(source.productPerformances)
+      const sumUnits = orders.reduce((total, order) => total + (order.totalQuantity ?? 0), 0)
+      const sumRevenue = performances.reduce((total, perf) => total + (perf.totalRevenue ?? 0), 0)
+      const orderCount = Number(source.orderCount)
+      const totalUnitsSold = Number(source.totalUnitsSold)
+      const totalSalesAmount = Number(source.totalSalesAmount)
+      const weekStart = typeof source.weekStart === 'string' ? source.weekStart : ''
+      const weekEnd = typeof source.weekEnd === 'string' ? source.weekEnd : ''
+
+      if (!weekStart || !weekEnd) return null
+
+      return {
+        weekStart,
+        weekEnd,
+        orderCount: Number.isFinite(orderCount) ? orderCount : orders.length,
+        totalUnitsSold: Number.isFinite(totalUnitsSold) ? totalUnitsSold : sumUnits,
+        totalSalesAmount: Number.isFinite(totalSalesAmount) ? totalSalesAmount : sumRevenue,
+        orders,
+        productPerformances: performances,
+      }
+    })
+    .filter((item): item is WeeklySalesStatistics => item !== null)
+}
 
 function formatNumber(value?: number | null) {
   if (typeof value !== 'number' || Number.isNaN(value)) return '0'

--- a/backend/src/main/java/com/example/silkmall/controller/AdminAnalyticsController.java
+++ b/backend/src/main/java/com/example/silkmall/controller/AdminAnalyticsController.java
@@ -1,0 +1,32 @@
+package com.example.silkmall.controller;
+
+import com.example.silkmall.dto.WeeklySalesStatisticsDTO;
+import com.example.silkmall.service.OrderService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admins/analytics")
+public class AdminAnalyticsController extends BaseController {
+
+    private final OrderService orderService;
+
+    @Autowired
+    public AdminAnalyticsController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @GetMapping("/weekly-sales")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<WeeklySalesStatisticsDTO>> getWeeklySales(
+            @RequestParam(value = "weeks", defaultValue = "6") int weeks) {
+        return success(orderService.getWeeklySalesStats(weeks));
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/WeeklyOrderDetailDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/WeeklyOrderDetailDTO.java
@@ -1,0 +1,61 @@
+package com.example.silkmall.dto;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+public class WeeklyOrderDetailDTO {
+    private Long id;
+    private String orderNo;
+    private BigDecimal totalAmount;
+    private Integer totalQuantity;
+    private String status;
+    private Date orderTime;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getOrderNo() {
+        return orderNo;
+    }
+
+    public void setOrderNo(String orderNo) {
+        this.orderNo = orderNo;
+    }
+
+    public BigDecimal getTotalAmount() {
+        return totalAmount;
+    }
+
+    public void setTotalAmount(BigDecimal totalAmount) {
+        this.totalAmount = totalAmount;
+    }
+
+    public Integer getTotalQuantity() {
+        return totalQuantity;
+    }
+
+    public void setTotalQuantity(Integer totalQuantity) {
+        this.totalQuantity = totalQuantity;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Date getOrderTime() {
+        return orderTime;
+    }
+
+    public void setOrderTime(Date orderTime) {
+        this.orderTime = orderTime;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/WeeklyProductPerformanceDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/WeeklyProductPerformanceDTO.java
@@ -1,0 +1,60 @@
+package com.example.silkmall.dto;
+
+import java.math.BigDecimal;
+
+public class WeeklyProductPerformanceDTO {
+    private Long productId;
+    private String productName;
+    private Long supplierId;
+    private String supplierName;
+    private Integer quantitySold;
+    private BigDecimal totalRevenue;
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Long productId) {
+        this.productId = productId;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+
+    public Long getSupplierId() {
+        return supplierId;
+    }
+
+    public void setSupplierId(Long supplierId) {
+        this.supplierId = supplierId;
+    }
+
+    public String getSupplierName() {
+        return supplierName;
+    }
+
+    public void setSupplierName(String supplierName) {
+        this.supplierName = supplierName;
+    }
+
+    public Integer getQuantitySold() {
+        return quantitySold;
+    }
+
+    public void setQuantitySold(Integer quantitySold) {
+        this.quantitySold = quantitySold;
+    }
+
+    public BigDecimal getTotalRevenue() {
+        return totalRevenue;
+    }
+
+    public void setTotalRevenue(BigDecimal totalRevenue) {
+        this.totalRevenue = totalRevenue;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/WeeklySalesStatisticsDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/WeeklySalesStatisticsDTO.java
@@ -1,0 +1,71 @@
+package com.example.silkmall.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public class WeeklySalesStatisticsDTO {
+    private LocalDate weekStart;
+    private LocalDate weekEnd;
+    private Integer orderCount;
+    private Integer totalUnitsSold;
+    private BigDecimal totalSalesAmount;
+    private List<WeeklyOrderDetailDTO> orders;
+    private List<WeeklyProductPerformanceDTO> productPerformances;
+
+    public LocalDate getWeekStart() {
+        return weekStart;
+    }
+
+    public void setWeekStart(LocalDate weekStart) {
+        this.weekStart = weekStart;
+    }
+
+    public LocalDate getWeekEnd() {
+        return weekEnd;
+    }
+
+    public void setWeekEnd(LocalDate weekEnd) {
+        this.weekEnd = weekEnd;
+    }
+
+    public Integer getOrderCount() {
+        return orderCount;
+    }
+
+    public void setOrderCount(Integer orderCount) {
+        this.orderCount = orderCount;
+    }
+
+    public Integer getTotalUnitsSold() {
+        return totalUnitsSold;
+    }
+
+    public void setTotalUnitsSold(Integer totalUnitsSold) {
+        this.totalUnitsSold = totalUnitsSold;
+    }
+
+    public BigDecimal getTotalSalesAmount() {
+        return totalSalesAmount;
+    }
+
+    public void setTotalSalesAmount(BigDecimal totalSalesAmount) {
+        this.totalSalesAmount = totalSalesAmount;
+    }
+
+    public List<WeeklyOrderDetailDTO> getOrders() {
+        return orders;
+    }
+
+    public void setOrders(List<WeeklyOrderDetailDTO> orders) {
+        this.orders = orders;
+    }
+
+    public List<WeeklyProductPerformanceDTO> getProductPerformances() {
+        return productPerformances;
+    }
+
+    public void setProductPerformances(List<WeeklyProductPerformanceDTO> productPerformances) {
+        this.productPerformances = productPerformances;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/repository/OrderRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/OrderRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,6 +29,9 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     @EntityGraph(attributePaths = {"orderItems", "orderItems.product", "orderItems.product.supplier", "consumer", "managingAdmin"})
     Page<Order> findByOrderNoContainingIgnoreCase(String orderNo, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"orderItems", "orderItems.product", "orderItems.product.supplier"})
+    List<Order> findByOrderTimeBetween(Date start, Date end);
 
     @EntityGraph(attributePaths = {"orderItems", "orderItems.product", "orderItems.product.supplier", "consumer", "managingAdmin"})
     Page<Order> findByConsumerConfirmationTimeIsNull(Pageable pageable);

--- a/backend/src/main/java/com/example/silkmall/service/OrderService.java
+++ b/backend/src/main/java/com/example/silkmall/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.example.silkmall.service;
 
+import com.example.silkmall.dto.WeeklySalesStatisticsDTO;
 import com.example.silkmall.entity.Order;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,4 +25,5 @@ public interface OrderService extends BaseService<Order, Long> {
     void approvePayout(Long id);
     Order findOrderDetail(Long id);
     Order updateContactInfo(Long id, String shippingAddress, String recipientName, String recipientPhone);
+    List<WeeklySalesStatisticsDTO> getWeeklySalesStats(int weeks);
 }

--- a/silkmall-frontend/src/types/index.ts
+++ b/silkmall-frontend/src/types/index.ts
@@ -308,6 +308,34 @@ export interface ProductReview {
   createdAt: string
 }
 
+export interface WeeklyOrderDetail {
+  id: number
+  orderNo: string
+  totalAmount: number
+  totalQuantity: number
+  status: string
+  orderTime: string
+}
+
+export interface WeeklyProductPerformance {
+  productId: number | null
+  productName: string
+  supplierId: number | null
+  supplierName: string
+  quantitySold: number
+  totalRevenue: number
+}
+
+export interface WeeklySalesStatistics {
+  weekStart: string
+  weekEnd: string
+  orderCount: number
+  totalUnitsSold: number
+  totalSalesAmount: number
+  orders: WeeklyOrderDetail[]
+  productPerformances: WeeklyProductPerformance[]
+}
+
 export interface ReturnRequest {
   id: number
   orderId: number

--- a/silkmall-frontend/src/views/dashboard/AdminOverview.vue
+++ b/silkmall-frontend/src/views/dashboard/AdminOverview.vue
@@ -8,6 +8,7 @@ import type {
   NewsItem,
   ProductOverview,
   ProductSummary,
+  WeeklySalesStatistics,
   CategoryOption,
   SupplierOption,
 } from '@/types'
@@ -33,6 +34,7 @@ const overview = ref<ProductOverview | null>(null)
 const announcements = ref<Announcement[]>([])
 const news = ref<NewsItem[]>([])
 const hotProducts = ref<ProductSummary[]>([])
+const weeklyStats = ref<WeeklySalesStatistics[]>([])
 const loading = ref(true)
 const error = ref<string | null>(null)
 
@@ -157,6 +159,14 @@ async function loadHomeContent() {
   announcements.value = parsed.announcements
   news.value = parsed.news
   hotProducts.value = parsed.hotSales.slice(0, 5)
+}
+
+async function loadWeeklySales() {
+  const response = await api.get<unknown>('/admins/analytics/weekly-sales', {
+    params: { weeks: 6 },
+  })
+  const parsed = unwrapData<WeeklySalesStatistics[]>(response.data)
+  weeklyStats.value = Array.isArray(parsed) ? parsed : []
 }
 
 async function loadWallet() {
@@ -647,7 +657,7 @@ async function bootstrap() {
   loading.value = true
   error.value = null
   try {
-    await Promise.all([loadOverview(), loadHomeContent(), loadWallet()])
+    await Promise.all([loadOverview(), loadHomeContent(), loadWallet(), loadWeeklySales()])
   } catch (err) {
     error.value = err instanceof Error ? err.message : '加载管理数据失败'
   } finally {
@@ -694,6 +704,24 @@ function formatDate(value?: string | Date | null) {
   const date = typeof value === 'string' ? new Date(value) : value
   if (Number.isNaN(date.getTime())) return '—'
   return date.toLocaleString('zh-CN', { hour12: false })
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '—'
+  return new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+function formatWeekRange(start?: string, end?: string) {
+  if (!start || !end) return '本周'
+  const formatter = new Intl.DateTimeFormat('zh-CN', { month: '2-digit', day: '2-digit' })
+  return `${formatter.format(new Date(start))} - ${formatter.format(new Date(end))}`
 }
 
 function formatNumber(value?: number | null) {
@@ -779,6 +807,78 @@ function formatNumber(value?: number | null) {
             <strong>{{ formatNumber(overview?.totalSalesVolume) }}</strong>
           </div>
         </div>
+      </section>
+
+      <section class="panel weekly" aria-labelledby="weekly-title">
+        <div class="panel-title" id="weekly-title">每周销售数据</div>
+        <p class="panel-subtitle">按周拆分订单与商品表现，快速洞察销量走势与供应商贡献。</p>
+
+        <div v-if="weeklyStats.length" class="week-grid">
+          <article v-for="week in weeklyStats" :key="week.weekStart" class="week-card">
+            <header class="week-header">
+              <div>
+                <p class="week-range">{{ formatWeekRange(week.weekStart, week.weekEnd) }}</p>
+                <p class="week-meta">订单 {{ formatNumber(week.orderCount) }} · 件数 {{ formatNumber(week.totalUnitsSold) }}</p>
+              </div>
+              <div class="week-amount">{{ formatCurrency(week.totalSalesAmount) }}</div>
+            </header>
+
+            <div class="week-body">
+              <div class="subpanel">
+                <div class="subpanel-title">订单明细</div>
+                <table v-if="week.orders.length" class="compact">
+                  <thead>
+                    <tr>
+                      <th scope="col">订单号</th>
+                      <th scope="col">金额</th>
+                      <th scope="col">数量</th>
+                      <th scope="col">状态</th>
+                      <th scope="col">下单时间</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="order in week.orders" :key="order.id">
+                      <td class="mono">{{ order.orderNo }}</td>
+                      <td>{{ formatCurrency(order.totalAmount) }}</td>
+                      <td>{{ formatNumber(order.totalQuantity) }}</td>
+                      <td>{{ order.status }}</td>
+                      <td>{{ formatDateTime(order.orderTime) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p v-else class="empty muted">本周暂无订单。</p>
+              </div>
+
+              <div class="subpanel">
+                <div class="subpanel-title">商品表现（按供应商拆分）</div>
+                <table v-if="week.productPerformances.length" class="compact">
+                  <thead>
+                    <tr>
+                      <th scope="col">商品</th>
+                      <th scope="col">供应商</th>
+                      <th scope="col">销量</th>
+                      <th scope="col">销售额</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr
+                      v-for="item in week.productPerformances"
+                      :key="`${item.productId}-${item.supplierId}`"
+                    >
+                      <td>{{ item.productName }}</td>
+                      <td>{{ item.supplierName }}</td>
+                      <td>{{ formatNumber(item.quantitySold) }}</td>
+                      <td>{{ formatCurrency(item.totalRevenue) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p v-else class="empty muted">暂无销售记录。</p>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <p v-else class="empty">暂无周度销售数据，等待订单积累后自动生成。</p>
       </section>
 
       <section class="panel product-admin" aria-labelledby="admin-product-title">
@@ -1362,6 +1462,107 @@ function formatNumber(value?: number | null) {
 .metric-grid strong {
   font-size: 1.4rem;
   font-weight: 700;
+}
+
+.weekly .panel-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.week-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.week-card {
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  border-radius: 16px;
+  padding: 1.2rem;
+  background: rgba(255, 255, 255, 0.85);
+  display: grid;
+  gap: 1rem;
+}
+
+.week-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.week-range {
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.week-meta {
+  color: rgba(15, 23, 42, 0.6);
+  margin-top: 0.2rem;
+}
+
+.week-amount {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: #f97316;
+}
+
+.week-body {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 900px) {
+  .week-body {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.subpanel {
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 12px;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.subpanel-title {
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.compact {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.compact th,
+.compact td {
+  padding: 0.35rem 0.55rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.compact th {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.compact td {
+  font-size: 0.9rem;
+}
+
+.compact tr:last-child td {
+  border-bottom: none;
+}
+
+.muted {
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.mono {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 }
 
 .hot-products table {


### PR DESCRIPTION
## Summary
- add weekly sales analytics DTOs and an admin endpoint to expose weekly order and product performance data
- aggregate order and product metrics per supplier to keep statistics separated when vendors sell similar items
- display weekly sales statistics on the admin overview page with updated frontend types

## Testing
- mvn -q -DskipTests package *(fails: unable to resolve parent POM because repo.maven.apache.org returned 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f57727f483308d9ebe465693ca40)