### PR TITLE
Add admin supplier account management

### DIFF
--- a/backend/src/main/java/com/example/silkmall/dto/SupplierCreateRequest.java
+++ b/backend/src/main/java/com/example/silkmall/dto/SupplierCreateRequest.java
@@ -1,0 +1,119 @@
+package com.example.silkmall.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class SupplierCreateRequest {
+    @NotBlank(message = "用户名不能为空")
+    @Size(max = 50, message = "用户名长度不能超过50个字符")
+    private String username;
+
+    @NotBlank(message = "密码不能为空")
+    @Size(min = 6, message = "密码至少6位字符")
+    private String password;
+
+    @Email(message = "邮箱格式不正确")
+    private String email;
+    private String phone;
+    private String address;
+
+    @NotBlank(message = "公司名称不能为空")
+    private String companyName;
+    private String businessLicense;
+
+    @NotBlank(message = "联系人不能为空")
+    private String contactPerson;
+
+    private String supplierLevel;
+    private String status;
+    private Boolean enabled;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public String getBusinessLicense() {
+        return businessLicense;
+    }
+
+    public void setBusinessLicense(String businessLicense) {
+        this.businessLicense = businessLicense;
+    }
+
+    public String getContactPerson() {
+        return contactPerson;
+    }
+
+    public void setContactPerson(String contactPerson) {
+        this.contactPerson = contactPerson;
+    }
+
+    public String getSupplierLevel() {
+        return supplierLevel;
+    }
+
+    public void setSupplierLevel(String supplierLevel) {
+        this.supplierLevel = supplierLevel;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/SupplierDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/SupplierDTO.java
@@ -1,0 +1,117 @@
+package com.example.silkmall.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class SupplierDTO {
+    private Long id;
+
+    @NotBlank(message = "用户名不能为空")
+    @Size(max = 50, message = "用户名长度不能超过50个字符")
+    private String username;
+
+    @Email(message = "邮箱格式不正确")
+    private String email;
+    private String phone;
+    private String address;
+
+    @NotBlank(message = "公司名称不能为空")
+    private String companyName;
+    private String businessLicense;
+
+    @NotBlank(message = "联系人不能为空")
+    private String contactPerson;
+
+    private String supplierLevel;
+    private String status;
+    private Boolean enabled;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public String getBusinessLicense() {
+        return businessLicense;
+    }
+
+    public void setBusinessLicense(String businessLicense) {
+        this.businessLicense = businessLicense;
+    }
+
+    public String getContactPerson() {
+        return contactPerson;
+    }
+
+    public void setContactPerson(String contactPerson) {
+        this.contactPerson = contactPerson;
+    }
+
+    public String getSupplierLevel() {
+        return supplierLevel;
+    }
+
+    public void setSupplierLevel(String supplierLevel) {
+        this.supplierLevel = supplierLevel;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/repository/NewSupplierRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/NewSupplierRepository.java
@@ -2,12 +2,14 @@ package com.example.silkmall.repository;
 
 import com.example.silkmall.entity.Supplier;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface NewSupplierRepository extends JpaRepository<Supplier, Long> {
+public interface NewSupplierRepository extends JpaRepository<Supplier, Long>,
+        JpaSpecificationExecutor<Supplier> {
     Optional<Supplier> findByUsername(String username);
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);

--- a/backend/src/main/java/com/example/silkmall/repository/SupplierRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/SupplierRepository.java
@@ -2,11 +2,13 @@ package com.example.silkmall.repository;
 
 import com.example.silkmall.entity.Supplier;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface SupplierRepository extends JpaRepository<Supplier, Long>, BaseUserRepository<Supplier> {
+public interface SupplierRepository extends JpaRepository<Supplier, Long>,
+        JpaSpecificationExecutor<Supplier>, BaseUserRepository<Supplier> {
     List<Supplier> findByStatus(String status);
     List<Supplier> findBySupplierLevel(String level);
 }

--- a/backend/src/main/java/com/example/silkmall/service/SupplierService.java
+++ b/backend/src/main/java/com/example/silkmall/service/SupplierService.java
@@ -1,11 +1,14 @@
 package com.example.silkmall.service;
 
 import com.example.silkmall.entity.Supplier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface SupplierService extends UserService<Supplier> {
     List<Supplier> findByStatus(String status);
     List<Supplier> findBySupplierLevel(String level);
+    Page<Supplier> search(String keyword, Boolean enabled, String supplierLevel, String status, Pageable pageable);
     void approveSupplier(Long id);
     void rejectSupplier(Long id, String reason);
     void updateSupplierLevel(Long id, String level);

--- a/silkmall-frontend/src/router/index.ts
+++ b/silkmall-frontend/src/router/index.ts
@@ -7,6 +7,7 @@ const ConsumerDashboard = () => import('../views/dashboard/ConsumerDashboard.vue
 const SupplierWorkbench = () => import('../views/dashboard/SupplierWorkbench.vue')
 const AdminOverview = () => import('../views/dashboard/AdminOverview.vue')
 const AdminConsumerManagement = () => import('../views/dashboard/AdminConsumerManagement.vue')
+const AdminSupplierManagement = () => import('../views/dashboard/AdminSupplierManagement.vue')
 const AdminProductManagement = () => import('../views/dashboard/AdminProductManagement.vue')
 const AdminOrderManagement = () => import('../views/dashboard/AdminOrderManagement.vue')
 const ProductDetailView = () => import('../views/ProductDetailView.vue')
@@ -83,6 +84,12 @@ const router = createRouter({
       path: '/admin/consumers',
       name: 'admin-consumers',
       component: AdminConsumerManagement,
+      meta: { requiresAuth: true, roles: ['admin'] },
+    },
+    {
+      path: '/admin/suppliers',
+      name: 'admin-suppliers',
+      component: AdminSupplierManagement,
       meta: { requiresAuth: true, roles: ['admin'] },
     },
   ],

--- a/silkmall-frontend/src/views/dashboard/AdminOverview.vue
+++ b/silkmall-frontend/src/views/dashboard/AdminOverview.vue
@@ -713,6 +713,7 @@ function formatNumber(value?: number | null) {
         <RouterLink class="manage-link" to="/admin/products">商品管理</RouterLink>
         <RouterLink class="manage-link" to="/admin/orders">订单管理</RouterLink>
         <RouterLink class="manage-link" to="/admin/consumers">采购账号管理</RouterLink>
+        <RouterLink class="manage-link" to="/admin/suppliers">供应商账号管理</RouterLink>
       </nav>
     </header>
 


### PR DESCRIPTION
## Summary
- add DTOs and pageable filtering endpoints to manage suppliers with create, update, delete, and enable/disable support
- extend supplier repositories and services with specification-based search for admin use
- add admin supplier management view and routing alongside overview link mirroring procurement management UI

## Testing
- `npm run build` *(fails: existing LoginView type-check errors surfaced during vue-tsc)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694402488464833081e47a15aecb2f93)