### PR TITLE
Add weekly sales analytics for admin dashboard

### DIFF
--- a/backend/src/main/java/com/example/silkmall/controller/AnalyticsController.java
+++ b/backend/src/main/java/com/example/silkmall/controller/AnalyticsController.java
@@ -1,0 +1,31 @@
+package com.example.silkmall.controller;
+
+import com.example.silkmall.dto.WeeklySalesReportDTO;
+import com.example.silkmall.service.OrderService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/analytics")
+public class AnalyticsController extends BaseController {
+
+    private final OrderService orderService;
+
+    @Autowired
+    public AnalyticsController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @GetMapping("/weekly-sales")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<WeeklySalesReportDTO> getWeeklySales(
+            @RequestParam(value = "weeks", required = false) Integer weeks) {
+        int resolvedWeeks = weeks == null ? 8 : weeks;
+        return success(orderService.getWeeklySalesReport(resolvedWeeks));
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/WeeklyOrderDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/WeeklyOrderDTO.java
@@ -1,0 +1,80 @@
+package com.example.silkmall.dto;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+
+public class WeeklyOrderDTO {
+    private Long id;
+    private String orderNo;
+    private BigDecimal totalAmount;
+    private Integer totalQuantity;
+    private String status;
+    private Date orderTime;
+    private Date paymentTime;
+    private List<WeeklyOrderItemDTO> items;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getOrderNo() {
+        return orderNo;
+    }
+
+    public void setOrderNo(String orderNo) {
+        this.orderNo = orderNo;
+    }
+
+    public BigDecimal getTotalAmount() {
+        return totalAmount;
+    }
+
+    public void setTotalAmount(BigDecimal totalAmount) {
+        this.totalAmount = totalAmount;
+    }
+
+    public Integer getTotalQuantity() {
+        return totalQuantity;
+    }
+
+    public void setTotalQuantity(Integer totalQuantity) {
+        this.totalQuantity = totalQuantity;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Date getOrderTime() {
+        return orderTime;
+    }
+
+    public void setOrderTime(Date orderTime) {
+        this.orderTime = orderTime;
+    }
+
+    public Date getPaymentTime() {
+        return paymentTime;
+    }
+
+    public void setPaymentTime(Date paymentTime) {
+        this.paymentTime = paymentTime;
+    }
+
+    public List<WeeklyOrderItemDTO> getItems() {
+        return items;
+    }
+
+    public void setItems(List<WeeklyOrderItemDTO> items) {
+        this.items = items;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/WeeklyOrderItemDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/WeeklyOrderItemDTO.java
@@ -1,0 +1,60 @@
+package com.example.silkmall.dto;
+
+import java.math.BigDecimal;
+
+public class WeeklyOrderItemDTO {
+    private Long productId;
+    private String productName;
+    private Long supplierId;
+    private String supplierName;
+    private Integer quantity;
+    private BigDecimal totalPrice;
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Long productId) {
+        this.productId = productId;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+
+    public Long getSupplierId() {
+        return supplierId;
+    }
+
+    public void setSupplierId(Long supplierId) {
+        this.supplierId = supplierId;
+    }
+
+    public String getSupplierName() {
+        return supplierName;
+    }
+
+    public void setSupplierName(String supplierName) {
+        this.supplierName = supplierName;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public BigDecimal getTotalPrice() {
+        return totalPrice;
+    }
+
+    public void setTotalPrice(BigDecimal totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/WeeklyProductPerformanceDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/WeeklyProductPerformanceDTO.java
@@ -1,0 +1,60 @@
+package com.example.silkmall.dto;
+
+import java.math.BigDecimal;
+
+public class WeeklyProductPerformanceDTO {
+    private Long productId;
+    private String productName;
+    private Long supplierId;
+    private String supplierName;
+    private Integer quantity;
+    private BigDecimal salesAmount;
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Long productId) {
+        this.productId = productId;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+
+    public Long getSupplierId() {
+        return supplierId;
+    }
+
+    public void setSupplierId(Long supplierId) {
+        this.supplierId = supplierId;
+    }
+
+    public String getSupplierName() {
+        return supplierName;
+    }
+
+    public void setSupplierName(String supplierName) {
+        this.supplierName = supplierName;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public BigDecimal getSalesAmount() {
+        return salesAmount;
+    }
+
+    public void setSalesAmount(BigDecimal salesAmount) {
+        this.salesAmount = salesAmount;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/WeeklySalesBucketDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/WeeklySalesBucketDTO.java
@@ -1,0 +1,71 @@
+package com.example.silkmall.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public class WeeklySalesBucketDTO {
+    private LocalDate weekStart;
+    private LocalDate weekEnd;
+    private int totalOrders;
+    private int totalQuantity;
+    private BigDecimal totalRevenue;
+    private List<WeeklyOrderDTO> orders;
+    private List<WeeklyProductPerformanceDTO> productPerformances;
+
+    public LocalDate getWeekStart() {
+        return weekStart;
+    }
+
+    public void setWeekStart(LocalDate weekStart) {
+        this.weekStart = weekStart;
+    }
+
+    public LocalDate getWeekEnd() {
+        return weekEnd;
+    }
+
+    public void setWeekEnd(LocalDate weekEnd) {
+        this.weekEnd = weekEnd;
+    }
+
+    public int getTotalOrders() {
+        return totalOrders;
+    }
+
+    public void setTotalOrders(int totalOrders) {
+        this.totalOrders = totalOrders;
+    }
+
+    public int getTotalQuantity() {
+        return totalQuantity;
+    }
+
+    public void setTotalQuantity(int totalQuantity) {
+        this.totalQuantity = totalQuantity;
+    }
+
+    public BigDecimal getTotalRevenue() {
+        return totalRevenue;
+    }
+
+    public void setTotalRevenue(BigDecimal totalRevenue) {
+        this.totalRevenue = totalRevenue;
+    }
+
+    public List<WeeklyOrderDTO> getOrders() {
+        return orders;
+    }
+
+    public void setOrders(List<WeeklyOrderDTO> orders) {
+        this.orders = orders;
+    }
+
+    public List<WeeklyProductPerformanceDTO> getProductPerformances() {
+        return productPerformances;
+    }
+
+    public void setProductPerformances(List<WeeklyProductPerformanceDTO> productPerformances) {
+        this.productPerformances = productPerformances;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/dto/WeeklySalesReportDTO.java
+++ b/backend/src/main/java/com/example/silkmall/dto/WeeklySalesReportDTO.java
@@ -1,0 +1,15 @@
+package com.example.silkmall.dto;
+
+import java.util.List;
+
+public class WeeklySalesReportDTO {
+    private List<WeeklySalesBucketDTO> weeks;
+
+    public List<WeeklySalesBucketDTO> getWeeks() {
+        return weeks;
+    }
+
+    public void setWeeks(List<WeeklySalesBucketDTO> weeks) {
+        this.weeks = weeks;
+    }
+}

--- a/backend/src/main/java/com/example/silkmall/repository/OrderRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/OrderRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,4 +35,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     @EntityGraph(attributePaths = {"orderItems", "orderItems.product", "orderItems.product.supplier", "consumer", "managingAdmin"})
     Page<Order> findByConsumerConfirmationTimeIsNotNull(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"orderItems", "orderItems.product", "orderItems.product.supplier", "consumer", "managingAdmin"})
+    List<Order> findByOrderTimeBetween(Date start, Date end);
 }

--- a/backend/src/main/java/com/example/silkmall/service/OrderService.java
+++ b/backend/src/main/java/com/example/silkmall/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.example.silkmall.service;
 
 import com.example.silkmall.entity.Order;
+import com.example.silkmall.dto.WeeklySalesReportDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import java.util.List;
@@ -24,4 +25,5 @@ public interface OrderService extends BaseService<Order, Long> {
     void approvePayout(Long id);
     Order findOrderDetail(Long id);
     Order updateContactInfo(Long id, String shippingAddress, String recipientName, String recipientPhone);
+    WeeklySalesReportDTO getWeeklySalesReport(int weeks);
 }

--- a/silkmall-frontend/src/router/index.ts
+++ b/silkmall-frontend/src/router/index.ts
@@ -10,6 +10,7 @@ const AdminConsumerManagement = () => import('../views/dashboard/AdminConsumerMa
 const AdminSupplierManagement = () => import('../views/dashboard/AdminSupplierManagement.vue')
 const AdminProductManagement = () => import('../views/dashboard/AdminProductManagement.vue')
 const AdminOrderManagement = () => import('../views/dashboard/AdminOrderManagement.vue')
+const AdminSalesStatistics = () => import('../views/dashboard/AdminSalesStatistics.vue')
 const ProductDetailView = () => import('../views/ProductDetailView.vue')
 
 const router = createRouter({
@@ -90,6 +91,12 @@ const router = createRouter({
       path: '/admin/suppliers',
       name: 'admin-suppliers',
       component: AdminSupplierManagement,
+      meta: { requiresAuth: true, roles: ['admin'] },
+    },
+    {
+      path: '/admin/sales',
+      name: 'admin-sales',
+      component: AdminSalesStatistics,
       meta: { requiresAuth: true, roles: ['admin'] },
     },
   ],

--- a/silkmall-frontend/src/types/index.ts
+++ b/silkmall-frontend/src/types/index.ts
@@ -292,6 +292,49 @@ export interface AdminOrderSummary {
   items: AdminOrderItem[]
 }
 
+export interface WeeklyOrderItem {
+  productId?: number | null
+  productName?: string | null
+  supplierId?: number | null
+  supplierName?: string | null
+  quantity: number
+  totalPrice: number
+}
+
+export interface WeeklyOrderSummary {
+  id: number
+  orderNo: string
+  totalAmount: number
+  totalQuantity: number
+  status?: string | null
+  orderTime?: string | null
+  paymentTime?: string | null
+  items: WeeklyOrderItem[]
+}
+
+export interface WeeklyProductPerformance {
+  productId?: number | null
+  productName?: string | null
+  supplierId?: number | null
+  supplierName?: string | null
+  quantity: number
+  salesAmount: number
+}
+
+export interface WeeklySalesBucket {
+  weekStart: string
+  weekEnd: string
+  totalOrders: number
+  totalQuantity: number
+  totalRevenue: number
+  orders: WeeklyOrderSummary[]
+  productPerformances: WeeklyProductPerformance[]
+}
+
+export interface WeeklySalesReport {
+  weeks: WeeklySalesBucket[]
+}
+
 export interface ProductReview {
   id: number
   orderId: number

--- a/silkmall-frontend/src/views/dashboard/AdminOverview.vue
+++ b/silkmall-frontend/src/views/dashboard/AdminOverview.vue
@@ -10,6 +10,7 @@ import type {
   ProductSummary,
   CategoryOption,
   SupplierOption,
+  WeeklySalesReport,
 } from '@/types'
 
 interface ProductDetail {
@@ -33,6 +34,10 @@ const overview = ref<ProductOverview | null>(null)
 const announcements = ref<Announcement[]>([])
 const news = ref<NewsItem[]>([])
 const hotProducts = ref<ProductSummary[]>([])
+const weeklySales = ref<WeeklySalesReport | null>(null)
+const weeklyLoading = ref(false)
+const weeklyError = ref<string | null>(null)
+const selectedWeeks = ref(6)
 const loading = ref(true)
 const error = ref<string | null>(null)
 
@@ -157,6 +162,22 @@ async function loadHomeContent() {
   announcements.value = parsed.announcements
   news.value = parsed.news
   hotProducts.value = parsed.hotSales.slice(0, 5)
+}
+
+async function loadWeeklySales() {
+  weeklyLoading.value = true
+  weeklyError.value = null
+  try {
+    const { data } = await api.get<WeeklySalesReport>('/analytics/weekly-sales', {
+      params: { weeks: selectedWeeks.value },
+    })
+    weeklySales.value = data ?? null
+  } catch (err) {
+    weeklySales.value = null
+    weeklyError.value = err instanceof Error ? err.message : '加载周度销售数据失败'
+  } finally {
+    weeklyLoading.value = false
+  }
 }
 
 async function loadWallet() {
@@ -647,7 +668,7 @@ async function bootstrap() {
   loading.value = true
   error.value = null
   try {
-    await Promise.all([loadOverview(), loadHomeContent(), loadWallet()])
+    await Promise.all([loadOverview(), loadHomeContent(), loadWallet(), loadWeeklySales()])
   } catch (err) {
     error.value = err instanceof Error ? err.message : '加载管理数据失败'
   } finally {
@@ -694,6 +715,21 @@ function formatDate(value?: string | Date | null) {
   const date = typeof value === 'string' ? new Date(value) : value
   if (Number.isNaN(date.getTime())) return '—'
   return date.toLocaleString('zh-CN', { hour12: false })
+}
+
+function formatDateOnly(value?: string | Date | null) {
+  if (!value) return '—'
+  const date = typeof value === 'string' ? new Date(value) : value
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleDateString('zh-CN')
+}
+
+function formatWeekRange(start?: string | null, end?: string | null) {
+  const startText = formatDateOnly(start)
+  const endText = formatDateOnly(end)
+  if (startText === '—' && endText === '—') return '—'
+  if (endText === '—') return startText
+  return `${startText} - ${endText}`
 }
 
 function formatNumber(value?: number | null) {
@@ -779,6 +815,103 @@ function formatNumber(value?: number | null) {
             <span>累计销量</span>
             <strong>{{ formatNumber(overview?.totalSalesVolume) }}</strong>
           </div>
+        </div>
+      </section>
+
+      <section class="panel weekly-sales" aria-labelledby="weekly-sales-title">
+        <header class="weekly-sales-header">
+          <div>
+            <div class="panel-title" id="weekly-sales-title">周度销售统计</div>
+            <p class="panel-subtitle">查看每周订单与商品表现，同名商品会按供应商分开统计。</p>
+          </div>
+          <label class="weeks-selector">
+            <span>统计周数</span>
+            <select v-model.number="selectedWeeks" @change="loadWeeklySales" :disabled="weeklyLoading">
+              <option :value="4">4 周</option>
+              <option :value="6">6 周</option>
+              <option :value="8">8 周</option>
+              <option :value="12">12 周</option>
+            </select>
+          </label>
+        </header>
+        <div v-if="weeklyLoading" class="placeholder">正在加载周度数据…</div>
+        <div v-else-if="weeklyError" class="placeholder is-error">{{ weeklyError }}</div>
+        <div v-else-if="!weeklySales?.weeks?.length" class="placeholder">暂无销售记录</div>
+        <div v-else class="weekly-grid">
+          <article v-for="week in weeklySales?.weeks" :key="week.weekStart" class="week-card">
+            <header class="week-card__header">
+              <div>
+                <div class="week-label">{{ formatWeekRange(week.weekStart, week.weekEnd) }}</div>
+                <p class="panel-subtitle">
+                  订单 {{ formatNumber(week.totalOrders) }} · 销量 {{ formatNumber(week.totalQuantity) }}
+                </p>
+              </div>
+              <div class="week-amount">{{ formatCurrency(week.totalRevenue) }}</div>
+            </header>
+            <div class="week-columns">
+              <div class="week-column">
+                <h4>订单明细</h4>
+                <table v-if="week.orders?.length" class="compact-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">订单号</th>
+                      <th scope="col">支付时间</th>
+                      <th scope="col">金额</th>
+                      <th scope="col">数量</th>
+                      <th scope="col">商品/供应商</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="order in week.orders" :key="order.id">
+                      <td>{{ order.orderNo }}</td>
+                      <td>{{ formatDate(order.paymentTime) }}</td>
+                      <td>{{ formatCurrency(order.totalAmount) }}</td>
+                      <td>{{ formatNumber(order.totalQuantity) }}</td>
+                      <td class="order-items">
+                        <div
+                          v-for="item in order.items"
+                          :key="`${order.id}-${item.productId}-${item.supplierId}-${item.productName}`"
+                          class="order-item-line"
+                        >
+                          <span class="product-name">{{ item.productName || '未命名商品' }}</span>
+                          <span class="supplier-chip" v-if="item.supplierName">{{ item.supplierName }}</span>
+                          <span class="supplier-chip muted" v-else>无供应商</span>
+                          × {{ formatNumber(item.quantity) }}
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p v-else class="empty">本周暂无订单数据</p>
+              </div>
+              <div class="week-column">
+                <h4>商品表现</h4>
+                <table v-if="week.productPerformances?.length" class="compact-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">商品 / 供应商</th>
+                      <th scope="col">销量</th>
+                      <th scope="col">销售额</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="product in week.productPerformances" :key="`${product.productId}-${product.supplierId}`">
+                      <td>
+                        <div class="product-line">
+                          <span class="product-name">{{ product.productName || '未命名商品' }}</span>
+                          <span class="supplier-chip" v-if="product.supplierName">{{ product.supplierName }}</span>
+                          <span class="supplier-chip muted" v-else>无供应商</span>
+                        </div>
+                      </td>
+                      <td>{{ formatNumber(product.quantity) }}</td>
+                      <td>{{ formatCurrency(product.salesAmount) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p v-else class="empty">暂无商品销量</p>
+              </div>
+            </div>
+          </article>
         </div>
       </section>
 
@@ -1363,6 +1496,137 @@ function formatNumber(value?: number | null) {
 .metric-grid strong {
   font-size: 1.4rem;
   font-weight: 700;
+}
+
+.weekly-sales {
+  gap: 1rem;
+}
+
+.weekly-sales-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.weeks-selector {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: rgba(30, 41, 59, 0.75);
+}
+
+.weeks-selector select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(30, 41, 59, 0.18);
+  min-width: 120px;
+}
+
+.weekly-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.week-card {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  background: rgba(248, 250, 252, 0.8);
+  display: grid;
+  gap: 1rem;
+}
+
+.week-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.week-label {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: #0f172a;
+}
+
+.week-amount {
+  font-weight: 700;
+  color: #2563eb;
+  font-size: 1.1rem;
+}
+
+.week-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.week-column h4 {
+  margin: 0 0 0.5rem;
+}
+
+.compact-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.93rem;
+}
+
+.compact-table thead {
+  background: rgba(15, 23, 42, 0.04);
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.compact-table th,
+.compact-table td {
+  padding: 0.5rem 0.35rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  vertical-align: top;
+}
+
+.compact-table tbody tr:nth-child(odd) {
+  background: rgba(59, 130, 246, 0.04);
+}
+
+.order-items {
+  line-height: 1.5;
+}
+
+.order-item-line,
+.product-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.product-name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.supplier-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.14);
+  color: #1d4ed8;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.supplier-chip.muted {
+  background: rgba(15, 23, 42, 0.06);
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.week-columns .empty {
+  margin: 0.25rem 0 0;
+  color: rgba(15, 23, 42, 0.6);
 }
 
 .hot-products table {

--- a/silkmall-frontend/src/views/dashboard/AdminSalesStatistics.vue
+++ b/silkmall-frontend/src/views/dashboard/AdminSalesStatistics.vue
@@ -1,0 +1,423 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import api from '@/services/api'
+import type { WeeklySalesReport } from '@/types'
+
+const weeklySales = ref<WeeklySalesReport | null>(null)
+const weeklyLoading = ref(false)
+const weeklyError = ref<string | null>(null)
+const selectedWeeks = ref(6)
+
+function formatCurrency(amount?: number | string | null) {
+  const numeric = typeof amount === 'string' ? Number(amount) : amount
+  if (typeof numeric !== 'number' || Number.isNaN(numeric)) {
+    return '¥0.00'
+  }
+  return new Intl.NumberFormat('zh-CN', { style: 'currency', currency: 'CNY' }).format(numeric)
+}
+
+function formatDate(value?: string | Date | null) {
+  if (!value) return '—'
+  const date = typeof value === 'string' ? new Date(value) : value
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleString('zh-CN', { hour12: false })
+}
+
+function formatDateOnly(value?: string | Date | null) {
+  if (!value) return '—'
+  const date = typeof value === 'string' ? new Date(value) : value
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleDateString('zh-CN')
+}
+
+function formatWeekRange(start?: string | null, end?: string | null) {
+  const startText = formatDateOnly(start)
+  const endText = formatDateOnly(end)
+  if (startText === '—' && endText === '—') return '—'
+  if (endText === '—') return startText
+  return `${startText} - ${endText}`
+}
+
+function formatNumber(value?: number | null) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '0'
+  return new Intl.NumberFormat('zh-CN').format(value)
+}
+
+async function loadWeeklySales() {
+  weeklyLoading.value = true
+  weeklyError.value = null
+  try {
+    const { data } = await api.get<WeeklySalesReport>('/analytics/weekly-sales', {
+      params: { weeks: selectedWeeks.value },
+    })
+    weeklySales.value = data ?? null
+  } catch (err) {
+    weeklySales.value = null
+    weeklyError.value = err instanceof Error ? err.message : '加载周度销售数据失败'
+  } finally {
+    weeklyLoading.value = false
+  }
+}
+
+onMounted(() => {
+  loadWeeklySales()
+})
+</script>
+
+<template>
+  <section class="admin-shell">
+    <header class="admin-header">
+      <div>
+        <h1>销售统计</h1>
+        <p>查看每周订单与商品表现，同名商品会按供应商分开统计。</p>
+      </div>
+      <nav class="admin-actions">
+        <RouterLink class="manage-link" to="/admin/products">商品管理</RouterLink>
+        <RouterLink class="manage-link" to="/admin/orders">订单管理</RouterLink>
+        <RouterLink class="manage-link" to="/admin/consumers">采购账号管理</RouterLink>
+        <RouterLink class="manage-link" to="/admin/suppliers">供应商账号管理</RouterLink>
+        <RouterLink class="manage-link" to="/admin/sales">销售统计</RouterLink>
+      </nav>
+    </header>
+
+    <section class="panel weekly-sales" aria-labelledby="weekly-sales-title">
+      <header class="weekly-sales-header">
+        <div>
+          <div class="panel-title" id="weekly-sales-title">周度销售统计</div>
+          <p class="panel-subtitle">查看每周订单与商品表现，同名商品会按供应商分开统计。</p>
+        </div>
+        <label class="weeks-selector">
+          <span>统计周数</span>
+          <select v-model.number="selectedWeeks" @change="loadWeeklySales" :disabled="weeklyLoading">
+            <option :value="4">4 周</option>
+            <option :value="6">6 周</option>
+            <option :value="8">8 周</option>
+            <option :value="12">12 周</option>
+          </select>
+        </label>
+      </header>
+      <div v-if="weeklyLoading" class="placeholder">正在加载周度数据…</div>
+      <div v-else-if="weeklyError" class="placeholder is-error">{{ weeklyError }}</div>
+      <div v-else-if="!weeklySales?.weeks?.length" class="placeholder">暂无销售记录</div>
+      <div v-else class="weekly-grid">
+        <article v-for="week in weeklySales?.weeks" :key="week.weekStart" class="week-card">
+          <header class="week-card__header">
+            <div>
+              <div class="week-label">{{ formatWeekRange(week.weekStart, week.weekEnd) }}</div>
+              <p class="panel-subtitle">
+                订单 {{ formatNumber(week.totalOrders) }} · 销量 {{ formatNumber(week.totalQuantity) }}
+              </p>
+            </div>
+            <div class="week-amount">{{ formatCurrency(week.totalRevenue) }}</div>
+          </header>
+          <div class="week-columns">
+            <div class="week-column">
+              <h4>订单明细</h4>
+              <table v-if="week.orders?.length" class="compact-table">
+                <thead>
+                  <tr>
+                    <th scope="col">订单号</th>
+                    <th scope="col">支付时间</th>
+                    <th scope="col">金额</th>
+                    <th scope="col">数量</th>
+                    <th scope="col">商品/供应商</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="order in week.orders" :key="order.id">
+                    <td>{{ order.orderNo }}</td>
+                    <td>{{ formatDate(order.paymentTime) }}</td>
+                    <td>{{ formatCurrency(order.totalAmount) }}</td>
+                    <td>{{ formatNumber(order.totalQuantity) }}</td>
+                    <td class="order-items">
+                      <div
+                        v-for="item in order.items"
+                        :key="`${order.id}-${item.productId}-${item.supplierId}-${item.productName}`"
+                        class="order-item-line"
+                      >
+                        <span class="product-name">{{ item.productName || '未命名商品' }}</span>
+                        <span class="supplier-chip" v-if="item.supplierName">{{ item.supplierName }}</span>
+                        <span class="supplier-chip muted" v-else>无供应商</span>
+                        × {{ formatNumber(item.quantity) }}
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <p v-else class="empty">本周暂无订单数据</p>
+            </div>
+            <div class="week-column">
+              <h4>商品表现</h4>
+              <table v-if="week.productPerformances?.length" class="compact-table">
+                <thead>
+                  <tr>
+                    <th scope="col">商品 / 供应商</th>
+                    <th scope="col">销量</th>
+                    <th scope="col">销售额</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="product in week.productPerformances" :key="`${product.productId}-${product.supplierId}`">
+                    <td>
+                      <div class="product-line">
+                        <span class="product-name">{{ product.productName || '未命名商品' }}</span>
+                        <span class="supplier-chip" v-if="product.supplierName">{{ product.supplierName }}</span>
+                        <span class="supplier-chip muted" v-else>无供应商</span>
+                      </div>
+                    </td>
+                    <td>{{ formatNumber(product.quantity) }}</td>
+                    <td>{{ formatCurrency(product.salesAmount) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p v-else class="empty">暂无商品销量</p>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+  </section>
+</template>
+
+<style scoped>
+.admin-shell {
+  padding: 24px 24px 48px;
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.admin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.admin-header h1 {
+  margin: 0;
+  font-size: 28px;
+  letter-spacing: 0.6px;
+}
+
+.admin-header p {
+  margin: 6px 0 0;
+  color: #5e6a71;
+}
+
+.admin-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.manage-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid #d8e3e8;
+  background: #f8fbfd;
+  color: #1f3a56;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.manage-link:hover {
+  background: #edf5fa;
+  border-color: #c6d8e2;
+}
+
+.panel {
+  background: #ffffff;
+  border: 1px solid #e3e8ef;
+  border-radius: 16px;
+  padding: 18px;
+  box-shadow: 0 10px 30px rgba(16, 55, 92, 0.06);
+}
+
+.panel-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.panel-subtitle {
+  color: #5b7083;
+  margin: 6px 0 0;
+  font-size: 14px;
+}
+
+.placeholder {
+  padding: 24px;
+  text-align: center;
+  color: #708399;
+  background: #f8fafc;
+  border: 1px dashed #d7e1ec;
+  border-radius: 12px;
+}
+
+.placeholder.is-error {
+  color: #c0392b;
+  background: #fff6f5;
+  border-color: #f1c4c0;
+}
+
+.weekly-sales {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.weekly-sales-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.weeks-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.weeks-selector span {
+  color: #4a5b6a;
+  font-weight: 600;
+}
+
+.weeks-selector select {
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  min-width: 120px;
+}
+
+.weekly-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.week-card {
+  border: 1px solid #e7edf3;
+  border-radius: 14px;
+  padding: 14px;
+  background: linear-gradient(180deg, #fcfeff 0%, #f6f9fc 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.week-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.week-label {
+  font-weight: 700;
+  color: #1f2d3d;
+}
+
+.week-amount {
+  font-weight: 800;
+  color: #0c5b9b;
+  font-size: 18px;
+}
+
+.week-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+.week-column h4 {
+  margin: 0 0 8px;
+  font-size: 15px;
+  color: #1c2f40;
+}
+
+.compact-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #ffffff;
+  border: 1px solid #e6eef5;
+}
+
+.compact-table th,
+.compact-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid #e6eef5;
+  text-align: left;
+  vertical-align: top;
+}
+
+.compact-table th {
+  background: #f0f6fb;
+  color: #33475b;
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.compact-table td {
+  color: #1f2d3d;
+  font-size: 13px;
+}
+
+.order-items {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.order-item-line {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.product-line {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.product-name {
+  font-weight: 600;
+}
+
+.supplier-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: #e6f2ff;
+  color: #0f4b85;
+  font-size: 12px;
+  border: 1px solid #c2ddff;
+}
+
+.supplier-chip.muted {
+  background: #f5f7fa;
+  border-color: #e2e8f0;
+  color: #6b7b8c;
+}
+
+.empty {
+  margin: 0;
+  padding: 10px;
+  color: #7a8a9e;
+  background: #f7fafc;
+  border: 1px dashed #d9e2ec;
+  border-radius: 8px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add weekly sales DTOs and analytics controller endpoint for admin weekly sales reporting
- compute weekly order and product performance per supplier in order service with new repository query
- surface configurable weekly sales dashboard section and typings on the admin overview page

## Testing
- npm run build *(fails: LoginView login payload/type mismatch unrelated to changes)*
- bash mvnw -q -DskipTests compile *(fails: Maven wrapper could not download Maven due to network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944060993f48330a5003742cfc92805)