### PR TITLE
Handle product deletion cascades

### DIFF
--- a/backend/src/main/java/com/example/silkmall/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/OrderItemRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     List<OrderItem> findByOrderId(Long orderId);
+    List<OrderItem> findByProductId(Long productId);
 }

--- a/backend/src/main/java/com/example/silkmall/repository/ProductReviewRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/ProductReviewRepository.java
@@ -4,6 +4,7 @@ import com.example.silkmall.entity.ProductReview;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -13,4 +14,6 @@ public interface ProductReviewRepository extends JpaRepository<ProductReview, Lo
     List<ProductReview> findByOrderId(Long orderId);
     boolean existsByOrderItemIdAndConsumer_Id(Long orderItemId, Long consumerId);
     List<ProductReview> findByConsumer_IdOrderByCreatedAtDesc(Long consumerId);
+    void deleteByOrderItemIdIn(Collection<Long> orderItemIds);
+    void deleteByProduct_Id(Long productId);
 }

--- a/backend/src/main/java/com/example/silkmall/repository/ReturnRequestRepository.java
+++ b/backend/src/main/java/com/example/silkmall/repository/ReturnRequestRepository.java
@@ -14,4 +14,6 @@ public interface ReturnRequestRepository extends JpaRepository<ReturnRequest, Lo
     List<ReturnRequest> findByOrderId(Long orderId);
     List<ReturnRequest> findByProduct_Supplier_Id(Long supplierId);
     List<ReturnRequest> findByAfterReceiptTrueOrderByRequestedAtDesc();
+    void deleteByOrderItemIdIn(Collection<Long> orderItemIds);
+    void deleteByProduct_Id(Long productId);
 }

--- a/backend/src/main/java/com/example/silkmall/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/example/silkmall/service/impl/ProductServiceImpl.java
@@ -6,6 +6,7 @@ import com.example.silkmall.entity.Product;
 import com.example.silkmall.entity.ProductSizeAllocation;
 import com.example.silkmall.repository.OrderItemRepository;
 import com.example.silkmall.repository.ProductRepository;
+import com.example.silkmall.repository.ProductReviewRepository;
 import com.example.silkmall.repository.ProductSizeAllocationRepository;
 import com.example.silkmall.repository.ReturnRequestRepository;
 import com.example.silkmall.service.ProductService;
@@ -30,17 +31,20 @@ public class ProductServiceImpl extends BaseServiceImpl<Product, Long> implement
     private final ProductSizeAllocationRepository productSizeAllocationRepository;
     private final ReturnRequestRepository returnRequestRepository;
     private final OrderItemRepository orderItemRepository;
+    private final ProductReviewRepository productReviewRepository;
 
     @Autowired
     public ProductServiceImpl(ProductRepository productRepository,
                               ProductSizeAllocationRepository productSizeAllocationRepository,
                               ReturnRequestRepository returnRequestRepository,
-                              OrderItemRepository orderItemRepository) {
+                              OrderItemRepository orderItemRepository,
+                              ProductReviewRepository productReviewRepository) {
         super(productRepository);
         this.productRepository = productRepository;
         this.productSizeAllocationRepository = productSizeAllocationRepository;
         this.returnRequestRepository = returnRequestRepository;
         this.orderItemRepository = orderItemRepository;
+        this.productReviewRepository = productReviewRepository;
     }
     
     @Override
@@ -154,9 +158,11 @@ public class ProductServiceImpl extends BaseServiceImpl<Product, Long> implement
                     .filter(Objects::nonNull)
                     .toList();
             if (!orderItemIds.isEmpty()) {
+                productReviewRepository.deleteByOrderItemIdIn(orderItemIds);
                 returnRequestRepository.deleteByOrderItemIdIn(orderItemIds);
             }
         }
+        productReviewRepository.deleteByProduct_Id(id);
         returnRequestRepository.deleteByProduct_Id(id);
 
         productRepository.delete(product);

--- a/backend/src/main/java/com/example/silkmall/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/example/silkmall/service/impl/ProductServiceImpl.java
@@ -1,10 +1,13 @@
 package com.example.silkmall.service.impl;
 
 import com.example.silkmall.dto.ProductOverviewDTO;
+import com.example.silkmall.entity.OrderItem;
 import com.example.silkmall.entity.Product;
 import com.example.silkmall.entity.ProductSizeAllocation;
+import com.example.silkmall.repository.OrderItemRepository;
 import com.example.silkmall.repository.ProductRepository;
 import com.example.silkmall.repository.ProductSizeAllocationRepository;
+import com.example.silkmall.repository.ReturnRequestRepository;
 import com.example.silkmall.service.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -25,13 +28,19 @@ import java.util.stream.Collectors;
 public class ProductServiceImpl extends BaseServiceImpl<Product, Long> implements ProductService {
     private final ProductRepository productRepository;
     private final ProductSizeAllocationRepository productSizeAllocationRepository;
+    private final ReturnRequestRepository returnRequestRepository;
+    private final OrderItemRepository orderItemRepository;
 
     @Autowired
     public ProductServiceImpl(ProductRepository productRepository,
-                              ProductSizeAllocationRepository productSizeAllocationRepository) {
+                              ProductSizeAllocationRepository productSizeAllocationRepository,
+                              ReturnRequestRepository returnRequestRepository,
+                              OrderItemRepository orderItemRepository) {
         super(productRepository);
         this.productRepository = productRepository;
         this.productSizeAllocationRepository = productSizeAllocationRepository;
+        this.returnRequestRepository = returnRequestRepository;
+        this.orderItemRepository = orderItemRepository;
     }
     
     @Override
@@ -128,6 +137,29 @@ public class ProductServiceImpl extends BaseServiceImpl<Product, Long> implement
         }
 
         return productRepository.findAll(specification, pageable);
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(Long id) {
+        Product product = productRepository.findById(id).orElse(null);
+        if (product == null) {
+            return;
+        }
+
+        List<OrderItem> orderItems = orderItemRepository.findByProductId(id);
+        if (!orderItems.isEmpty()) {
+            List<Long> orderItemIds = orderItems.stream()
+                    .map(OrderItem::getId)
+                    .filter(Objects::nonNull)
+                    .toList();
+            if (!orderItemIds.isEmpty()) {
+                returnRequestRepository.deleteByOrderItemIdIn(orderItemIds);
+            }
+        }
+        returnRequestRepository.deleteByProduct_Id(id);
+
+        productRepository.delete(product);
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- add repository helpers for loading order items by product and cleaning up return requests
- remove return request records tied to a product before deleting it to avoid foreign key violations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b446a78f08330a96fc00e10a7d4cf)